### PR TITLE
Add script to link glsp projects for local development

### DIFF
--- a/development/yarn-link.sh
+++ b/development/yarn-link.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+function linkLocalModule(){
+    _moduleName=${1}
+    _baseDir=$PWD
+    cd $_moduleName && yarn $2 && cd $_baseDir
+}
+
+function linkExampleNodeModules(){
+    cd $2 || exit
+    echo $2
+    pwd
+    cd glsp-examples/client/node_modules/ || exit
+    linkLocalModule @theia/application-manager $1 
+    linkLocalModule @theia/application-package $1
+    linkLocalModule @theia/core $1 
+    linkLocalModule @theia/editor $1
+    linkLocalModule @theia/filesystem $1
+    linkLocalModule @theia/languages $1
+    linkLocalModule @theia/markers $1
+    linkLocalModule @theia/monaco $1
+    linkLocalModule @theia/navigator $1
+    linkLocalModule @theia/node-pty $1
+    linkLocalModule @theia/outline-view $1
+    linkLocalModule @theia/output $1
+    linkLocalModule @theia/process $1
+    linkLocalModule @theia/variable-resolver $1
+    linkLocalModule @theia/workspace $1
+    linkLocalModule sprotty-theia $1
+    linkLocalModule sprotty $1
+}
+
+function linkExample(){
+    cd $2 || exit
+    cd glsp-examples/client || exit
+    yarn $1 @eclipse-glsp/theia-integration
+    yarn $1 @eclipse-glsp/client
+    yarn install --force
+}
+
+function linkClient(){
+    cd $2 || exit
+    cd glsp-client || exit
+    yarn $1 sprotty
+    yarn $1
+    yarn install --force
+}
+
+function linkTheiaIntegration(){
+    cd $2 ||exit
+    cd glsp-theia-integration || exit
+    yarn $1 @eclipse-glsp/client
+    yarn $1 @theia/application-manager
+    yarn $1 @theia/application-package
+    yarn $1 @theia/core
+    yarn $1 @theia/editor
+    yarn $1 @theia/filesystem
+    yarn $1 @theia/languages
+    yarn $1 @theia/markers
+    yarn $1 @theia/monaco
+    yarn $1 @theia/navigator
+    yarn $1 @theia/node-pty
+    yarn $1 @theia/outline-view
+    yarn $1 @theia/output
+    yarn $1 @theia/process
+    yarn $1 @theia/variable-resolver
+    yarn $1 @theia/workspace
+    yarn $1 sprotty-theia
+    yarn $1
+    yarn install --force
+}
+
+#### MAIN Script
+baseDir=$(cd $1|| exit; pwd)
+if [[ "$baseDir" == "" ]]; then
+    echo "ERROR: No basedir was defined"
+    exit 0
+fi
+
+linkCmd="link"
+if [[ "$2" == "--unlink" ]]; then
+    linkCmd="unlink"
+    
+fi
+
+cd $baseDir || exit
+if [[ "$2" != "--unlink" ]]; then
+    # cd glsp-examples/client
+    # yarn install
+    linkExampleNodeModules $linkCmd $baseDir
+    linkClient $linkCmd $baseDir
+    linkTheiaIntegration $linkCmd $baseDir
+    linkExample $linkCmd $baseDir
+else
+    linkTheiaIntegration $linkCmd $baseDir
+    linkClient $linkCmd $baseDir
+    linkExampleNodeModules $linkCmd $baseDir
+    linkExample
+fi

--- a/development/yarn-link.sh
+++ b/development/yarn-link.sh
@@ -7,12 +7,11 @@ function linkLocalModule(){
 
 function linkExampleNodeModules(){
     cd $2 || exit
-    echo $2
     pwd
     cd glsp-examples/client/node_modules/ || exit
-    linkLocalModule @theia/application-manager $1 
+    linkLocalModule @theia/application-manager $1
     linkLocalModule @theia/application-package $1
-    linkLocalModule @theia/core $1 
+    linkLocalModule @theia/core $1
     linkLocalModule @theia/editor $1
     linkLocalModule @theia/filesystem $1
     linkLocalModule @theia/languages $1
@@ -84,15 +83,19 @@ fi
 
 cd $baseDir || exit
 if [[ "$2" != "--unlink" ]]; then
-    # cd glsp-examples/client
-    # yarn install
+    "--- Start linking all necessary packages --- "
+    cd glsp-examples/client || exit
+    yarn install
     linkExampleNodeModules $linkCmd $baseDir
     linkClient $linkCmd $baseDir
     linkTheiaIntegration $linkCmd $baseDir
     linkExample $linkCmd $baseDir
+    "--- LINKING SUCCESSFULL --- "
 else
+    "--- Start unlinking all previously linked packages --- "
     linkTheiaIntegration $linkCmd $baseDir
     linkClient $linkCmd $baseDir
     linkExampleNodeModules $linkCmd $baseDir
-    linkExample
+    linkExample $linkCmd $baseDir
+    "--- UNLINKING SUCCESSFULL --- "
 fi

--- a/glsp.code-workspace
+++ b/glsp.code-workspace
@@ -176,6 +176,43 @@
 				"problemMatcher": [
 					"$tsc-watch"
 				]
+			},
+			{
+				"label": "Yarn link all packages",
+				"detail": "Links all packages to the local source and shared dependencies",
+				"type": "shell",
+				"group": "none",
+				"presentation": {
+					"focus": false,
+					"panel": "shared",
+					"showReuseMessage": false,
+					"clear": true
+				},
+				"linux": {
+					"command": "./development/yarn-link.sh ${workspaceFolder}/../",
+				},
+				"osx": {
+					"command": "./development/yarn-link.sh ${workspaceFolder}/../",
+				},
+				"problemMatcher": []
+			},
+			{
+				"label": "Yarn unlink all packages",
+				"type": "shell",
+				"group": "none",
+				"presentation": {
+					"focus": false,
+					"panel": "shared",
+					"showReuseMessage": false,
+					"clear": true
+				},
+				"linux": {
+					"command": "./development/yarn-link.sh ${workspaceFolder}/../ --unlink",
+				},
+				"osx": {
+					"command": "./development/yarn-link.sh ${workspaceFolder}/../ --unlink",
+				},
+				"problemMatcher": []
 			}
 		]
 	}

--- a/glsp.code-workspace
+++ b/glsp.code-workspace
@@ -189,10 +189,16 @@
 					"clear": true
 				},
 				"linux": {
-					"command": "./development/yarn-link.sh ${workspaceFolder}/../",
+					"command": "./development/yarn-link.sh",
+					"args": [
+						"${workspaceFolder}/../"
+					]
 				},
 				"osx": {
-					"command": "./development/yarn-link.sh ${workspaceFolder}/../",
+					"command": "./development/yarn-link.sh",
+					"args": [
+						"${workspaceFolder}/../"
+					]
 				},
 				"problemMatcher": []
 			},
@@ -207,10 +213,18 @@
 					"clear": true
 				},
 				"linux": {
-					"command": "./development/yarn-link.sh ${workspaceFolder}/../ --unlink",
+					"command": "./development/yarn-link.sh",
+					"args": [
+						"${workspaceFolder}/../",
+						"--unlink"
+					]
 				},
 				"osx": {
-					"command": "./development/yarn-link.sh ${workspaceFolder}/../ --unlink",
+					"command": "./development/yarn-link.sh",
+					"args": [
+						"${workspaceFolder}/../",
+						"--unlink"
+					]
 				},
 				"problemMatcher": []
 			}


### PR DESCRIPTION
Expects that all glsp projects folders are in the same parent directory.
Usage:

-  <b>Linking</b>: `./yarn-link path/to/parent `
- <b> Unlinking</b>: `./yarn-link path/to/parent --unlink`
