### PR TITLE
Fixes attribute name in SelectAction

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1293,12 +1293,12 @@ class SelectAction implements Action {
     /**
      * The identifier of the elements to mark as selected.
      */
-    public readonly selectedElementsIds: string[] = [];
+    public readonly selectedElementsIDs: string[] = [];
 
     /**
      * The identifier of the elements to mark as not selected.
      */
-    public readonly deselectedElementsIds: string[] = [];
+    public readonly deselectedElementsIDs: string[] = [];
 }
 ```
 </details>


### PR DESCRIPTION
In the server and in Sprotty it is named `selectedElementsIDs` and `selectedElementsIDs`.
See
https://github.com/eclipse-glsp/glsp-https://github.com/eclipse-glsp/glsp-server/blob/4a1d17fc858f705cd45fa768daa740acb58ba6d4/plugins/org.eclipse.glsp.server/src/org/eclipse/glsp/server/actions/SelectAction.java#L24-L25
and
https://github.com/eclipse/sprotty/blob/69a773d1a76e253195102464d3ebfd932abbf4d3/src/features/select/select.ts#L49-L50

Fixes https://github.com/eclipse-glsp/glsp/issues/261