### PR TITLE
Add root option to index.js

### DIFF
--- a/config/packages/eslint-config/index.js
+++ b/config/packages/eslint-config/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-    extends: ["./no-prettier", "prettier"],
+    extends: ['./no-prettier', 'prettier'],
+    root: 'true'
 };


### PR DESCRIPTION
The missing option can lead to ESLint failures during the build.