### PR TITLE
[Config] Add prettier as dependency to meta package

### DIFF
--- a/config/packages/config/package.json
+++ b/config/packages/config/package.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "@eclipse-glsp/eslint-config": "0.1.0",
     "@eclipse-glsp/prettier-config": "0.1.0",
-    "@eclipse-glsp/ts-config": "0.1.0"
+    "@eclipse-glsp/ts-config": "0.1.0",
+    "prettier": "^2.4.1"
   },
   "devDependencies": {
     "typescript": "^3.9.2"
-  },
-  "prettier": "@eclipse-glsp/prettier-config"
+  }
 }

--- a/config/yarn.lock
+++ b/config/yarn.lock
@@ -2676,6 +2676,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
This ensures that prettier is installed as local module when @eclipse-glsp/config is added as dev dependency