### PR TITLE
#529 Add GitHub issue templates to the repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,8 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+labels: bug
+---
+
+<!-- Please provide a detailed description of the bug and provide any additional information available. -->
+<!-- Additional information can be in the form of logs, screenshots, screencasts. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/eclipse-glsp/glsp/discussions
+    about: Please ask questions on the Eclipse GLSP discussions page.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+<!-- Is your feature request related to a problem? Please describe -->
+<!-- Describe the solution you'd like -->
+<!-- Describe alternatives you've considered -->


### PR DESCRIPTION
The issue templates for bugs and feature requests automatically apply the respective label to new issues.
Disable blank issues and add a button that redirects to the GLSP discussions board for pure questions.

Fixes https://github.com/eclipse-glsp/glsp/issues/529

Please see also the PRs of the specific repositories:
- [x] https://github.com/eclipse-glsp/glsp-client/pull/165
- [x] https://github.com/eclipse-glsp/glsp-eclipse-integration/pull/46
- [x] https://github.com/eclipse-glsp/glsp-examples/pull/88
- [x] https://github.com/eclipse-glsp/glsp-server/pull/150
- [x] https://github.com/eclipse-glsp/glsp-server-node/pull/8
- [x] https://github.com/eclipse-glsp/glsp-theia-integration/pull/107
- [x] https://github.com/eclipse-glsp/glsp-vscode-integration/pull/23