### PR TITLE
Update docker images to node 14

### DIFF
--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -13,10 +13,10 @@
 
 ## Supported tags and respective `Dockerfile` links
 
--   [`latest`, `ubuntu`, `ubuntu-18.04`, `ubuntu-base`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/ubuntu/Dockerfile)
--   [`uitest`, `uitest-ubuntu-18.04`, `ubuntu-chrome`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/uitest/Dockerfile)
+-   [`latest`, `ubuntu`, `ubuntu-v2.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/ubuntu/Dockerfile)
+-   [`uitest`,`uitest-v2.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/uitest/Dockerfile)
 
--   [`alpine`, `alpine-3.12`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/alpine/Dockerfile)
+-   [`alpine`, `alpine-v2.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/alpine/Dockerfile)
 
 Note that these tags are fluent and not bound to a fixed image version. If you want to use a fixed version you can use the base tag with a version suffix e.g. `ubuntu-v1.0`. An increment of the major version number (e.g. v1.0-> v2.0) indicates an update of a major component e.g a new OS, Node or Java version.
 
@@ -27,7 +27,7 @@ Collection of images that are used in Continuos Integration jobs of Eclipse GLSP
 Currently each image variant has at least the following components installed:
 
 -   Git >=2.17.1
--   Node 12 and yarn 1.22.4
+-   Node 14 and yarn 1.22.4
 -   OpenJDK 11 and Maven >=3.6.0
 -   Python and GCC libraries to enable [Theia](https://theia-ide.org/) builds
 
@@ -51,13 +51,13 @@ This is the defacto base image. If you are unsure about what your needs are, you
 
 As the name indicates this image builds onto of [Ubuntu](https://ubuntu.com/). This makes it very easy to use and customize but also results in a larger image size compared to the `alpine` variant.
 
-## `node:alpine<-suffix>`
+## `ci:alpine<-suffix>`
 
 This image is based on the popular [Alpine Linux project](https://alpinelinux.org), available in [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
 
 It only provides the essential libraries needed for building client and server components and is the recommended image for classical CI jobs like building branches or PRs on change, or deploying build artifacts. Due to its slim size, it cannot be used for more sophisticated jobs like UI-Testing out-of-the-box, because essential components like a display server or a browser are not included.
 
-## `node:uitest<-suffix>`
+## `ci:uitest<-suffix>`
 
 This is the recommend image for CI jobs that execute any sort of UI tests. It uses the same base as the `ubuntu` image but has additional libraries installed (including Xvfb which enables headless UI testing). In addition, Google Chrome is installed which enables browser-based UI testing of client components.
 

--- a/docker/ci/alpine/Dockerfile
+++ b/docker/ci/alpine/Dockerfile
@@ -1,15 +1,15 @@
 # eclipseglsp/ci:alpine
 # 1.0
-FROM alpine:3.12
+FROM alpine:3.13
 
 # Install Java, Maven, Git and dependecies for Theia
 ENV JAVA_HOME="/usr/lib/jvm/default-jvm/"
 RUN apk add --no-cache openjdk11 maven git openssh \
     make pkgconfig gcc g++ python3  libx11-dev libxkbfile-dev libsecret-dev
-# Install node 12 and yarn
+# Install node 14 and yarn
 RUN  apk -U upgrade && apk add --repository https://dl-cdn.alpinelinux.org/alpine/v3.12/main/ --no-cache \
-    "nodejs<14" \
-    "nodejs-npm<14" \
+    "nodejs<16" \
+    "nodejs-npm<16" \
     yarn \
     curl
 

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && \
     #Install tools
     apt-get install wget gnupg curl make maven git g++-multilib g++-5-multilib libx11-dev libxkbfile-dev libsecret-1-dev -y && \
     #Install node
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install nodejs -y && \
     npm install -g yarn

--- a/docker/ci/uitest/Dockerfile
+++ b/docker/ci/uitest/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     #Install tools
     apt-get install wget gnupg curl make maven git g++-multilib g++-5-multilib libx11-dev libxkbfile-dev libsecret-1-dev -y && \
     #Install node
-    curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install nodejs -y && \
     npm install -g yarn &&\
     apt-get install lsof xvfb -y


### PR DESCRIPTION
Update readme and remove no longer supported tags
Part of https://github.com/eclipse-glsp/glsp/issues/676