### PR TITLE
Add command for workflow server download

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ All changes on the master branch are deployed automatically to the corresponding
 
 ### Client packages
 
-You’ll need node in version 12:
+You’ll need node in version >=14 :
 
 ```bash
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
-nvm install 12
+nvm install 14
 ```
 
 and Yarn

--- a/dev-packages/cli/README.md
+++ b/dev-packages/cli/README.md
@@ -1,7 +1,7 @@
 # Eclipse GLSP - CLI
 
 The `@eclipse-glsp/cli` package provides helpful scripts and commands for extension and application development.
-The contributed `glsp`, is a command line tool that offers all contributed commands.
+The contributed `glsp` binary is a command line tool that offers all contributed commands.
 
 ## Getting Started
 
@@ -13,10 +13,14 @@ yarn add @eclipse-glsp/cli --dev
 
 ## Commands
 
-Eclipse GLSP committers can use the `release` following command to prepare & publish a new Github release
+The `glsp` CLI tool offers the following commands
+
+### release
+
+Eclipse GLSP committers can use the `release` command to prepare & publish a new Github release
 for a specific GLSP component.
 
-```bash
+```console
 $ glsp release -h
 Usage: glsp release [options] <component> <releaseType> [customVersion]
 
@@ -28,15 +32,33 @@ Arguments:
   customVersion                    Custom version number. Will be ignored if the release type is not "custom"
 
 Options:
-  -V, --version                    output the version number
   -f, --force                      Enable force mode (default: false)
-  -d, --checkoutDir <checkoutDir>  The git checkout directory (default: "/home/tobias/Git/OpenSource/glsp/glsp/dev-packages/cli")
+  -d, --checkoutDir <checkoutDir>  The git checkout directory (default: "cwd")
   -b, --branch <branch>            The git branch to checkout (default: "master")
   -v, --verbose                    Enable verbose (debug) log output (default: false)
   --no-publish                     Only prepare release but do not publish to github
   --draft                          Publish github releases as drafts (default: false)
   --npm-dryRun                     Execute a npm dry-run for inspection. Publishes to the local npm registry and does not publish to github (default: false)
   -h, --help                       display help for command
+```
+
+### download:workflowServer
+
+The `download:workflowServer` command can be used to download a specific version of the Java Workflow GLSP Server from maven.
+
+```console
+$ glsp download:workflowServer
+Usage: glsp download:workflowServer [options] <downloadDir> <version>
+
+Download the Workflow Example Server jar
+
+Arguments:
+  downloadDir   The target download directory
+  version       The base version of the server jar
+
+Options:
+  --isSnapshot  Flag to consume the snapshot version
+  -h, --help    display help for command
 ```
 
 ## More information

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -24,12 +24,12 @@
     }
   ],
   "scripts": {
-    "prepare": "yarn clean && yarn build && yarn lint",
-    "clean": "rimraf lib tsconfig.tsbuildinfo ",
+    "prepare": "yarn clean && yarn build",
     "build": "tsc",
+    "clean": "rimraf lib tsconfig.tsbuildinfo ",
     "lint": "eslint --ext .ts,.tsx ./src",
-    "lint:fix": "eslint --fix --ext .ts,.tsx ./src",
-    "test": "node --enable-source-maps lib/app.js"
+    "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
+    "test:cli": "node --enable-source-maps lib/app.js"
   },
   "publishConfig": {
     "access": "public"
@@ -39,7 +39,8 @@
     "shelljs": "0.8.5",
     "semver": "^7.3.7",
     "node-fetch": "2.6.7",
-    "readline-sync": "^1.4.10"
+    "readline-sync": "^1.4.10",
+    "mvn-artifact-download": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/dev-packages/cli/src/app.ts
+++ b/dev-packages/cli/src/app.ts
@@ -14,36 +14,17 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Argument, Command } from 'commander';
-import * as sh from 'shelljs';
-import { Component, ReleaseType } from './release/common';
-import { release } from './release/release';
+import { ReleaseCommand } from './release/release';
+import { DownloadWorkflowServerCommand } from './scripts/download-workflow-server';
 import { baseConfiguration } from './util/command-util';
-import { validateDirectory, validateVersion } from './util/validation-util';
+export const COMMAND_VERSION = '1.1.0-next';
 
-export const ReleaseCommand = baseConfiguration(new Command())
-    .name('release')
-    .description('Prepare & publish a new release for a glsp component')
-    .addArgument(new Argument('<component>', 'The glsp component to be released').choices(Component.CLI_CHOICES).argParser(Component.parse))
-    .addArgument(new Argument('<releaseType>', 'The release type').choices(ReleaseType.CLI_CHOICES))
-    .argument('[customVersion]', 'Custom version number. Will be ignored if the release type is not "custom"', validateVersion)
-    .option('-f, --force', 'Enable force mode', false)
-    .option('-d, --checkoutDir <checkoutDir>', 'The git checkout directory', validateDirectory, sh.pwd().stdout)
-    .option('-b, --branch <branch>', 'The git branch to checkout', 'master')
-    .option('-v, --verbose', 'Enable verbose (debug) log output', false)
-    .option('--no-publish', 'Only prepare release but do not publish to github', true)
-    .option('--draft', 'Publish github releases as drafts', false)
-    .option(
-        '--npm-dryRun',
-        'Execute a npm dry-run for inspection. Publishes to the local npm registry and does not publish to github',
-        false
-    )
-    .action(release);
-
-const app = baseConfiguration(new Command())
+const app = baseConfiguration()
+    .version(COMMAND_VERSION)
     .showSuggestionAfterError(true)
     .showHelpAfterError(true)
     .name('glsp')
-    .addCommand(ReleaseCommand);
+    .addCommand(ReleaseCommand)
+    .addCommand(DownloadWorkflowServerCommand);
 
 app.parse(process.argv);

--- a/dev-packages/cli/src/release/release.ts
+++ b/dev-packages/cli/src/release/release.ts
@@ -14,15 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ChildProcess } from 'child_process';
+import { Argument } from 'commander';
 import { exit } from 'process';
 import { createInterface } from 'readline';
 import * as readline from 'readline-sync';
 import * as semver from 'semver';
 import * as sh from 'shelljs';
-import { BaseCmdOptions, fatalExec, getShellConfig, initialConfiguration } from '../util/command-util';
+import { BaseCmdOptions, baseConfiguration, fatalExec, getShellConfig, initialConfiguration } from '../util/command-util';
 import { isGithubCLIAuthenticated } from '../util/git-util';
 import { LOGGER } from '../util/logger';
-import { validateVersion } from '../util/validation-util';
+import { validateDirectory, validateVersion } from '../util/validation-util';
 import {
     asMvnVersion,
     checkIfMavenVersionExists,
@@ -49,6 +50,25 @@ interface ReleaseCmdOptions extends BaseCmdOptions {
 
 let verdaccioChildProcess: ChildProcess | undefined = undefined;
 
+export const ReleaseCommand = baseConfiguration()
+    .name('release')
+    .description('Prepare & publish a new release for a glsp component')
+    .addArgument(new Argument('<component>', 'The glsp component to be released').choices(Component.CLI_CHOICES).argParser(Component.parse))
+    .addArgument(new Argument('<releaseType>', 'The release type').choices(ReleaseType.CLI_CHOICES))
+    .argument('[customVersion]', 'Custom version number. Will be ignored if the release type is not "custom"', validateVersion)
+    .option('-f, --force', 'Enable force mode', false)
+    .option('-d, --checkoutDir <checkoutDir>', 'The git checkout directory', validateDirectory, sh.pwd().stdout)
+    .option('-b, --branch <branch>', 'The git branch to checkout', 'master')
+    .option('-v, --verbose', 'Enable verbose (debug) log output', false)
+    .option('--no-publish', 'Only prepare release but do not publish to github', true)
+    .option('--draft', 'Publish github releases as drafts', false)
+    .option(
+        '--npm-dryRun',
+        'Execute a npm dry-run for inspection. Publishes to the local npm registry and does not publish to github',
+        false
+    )
+    .action(release);
+
 export async function release(
     component: Component,
     releaseType: ReleaseType,
@@ -56,8 +76,8 @@ export async function release(
     cliOptions: ReleaseCmdOptions
 ): Promise<void> {
     try {
-        LOGGER.debug('Cli options:', cliOptions);
         initialConfiguration(cliOptions.verbose);
+        LOGGER.debug('Cli options:', cliOptions);
         checkGHCli();
         const version = deriveVersion(releaseType, customVersion);
         const options: ReleaseOptions = { ...cliOptions, component, releaseType, version };

--- a/dev-packages/cli/src/scripts/download-workflow-server.ts
+++ b/dev-packages/cli/src/scripts/download-workflow-server.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import download, { Artifact } from 'mvn-artifact-download';
+import { baseConfiguration } from '../util/command-util';
+import { LOGGER } from '../util/logger';
+import { validateBaseVersion, validateDirectory } from '../util/validation-util';
+
+interface CmdOptions {
+    isSnapshot: boolean;
+}
+
+export const DownloadWorkflowServerCommand = baseConfiguration()
+    .name('download:workflowServer')
+    .description('Download the Workflow Example Server jar')
+    .argument('<downloadDir>', 'The target download directory', validateDirectory)
+    .argument('<version>', 'The base version of the server jar', validateBaseVersion)
+    .option('--isSnapshot', 'Flag to consume the snapshot version')
+    .action(downloadWorkflowServer);
+
+const RELEASE_REPO = 'https://repo1.maven.org/maven2/';
+const SNAPSHOT_REPO = 'https://oss.sonatype.org/content/repositories/snapshots/';
+const ARTIFACT_TEMPLATE: Artifact = {
+    groupId: 'org.eclipse.glsp.example',
+    artifactId: 'org.eclipse.glsp.example.workflow',
+    version: 'TO_REPLACE',
+    isSnapShot: false,
+    classifier: 'glsp'
+};
+
+export function downloadWorkflowServer(downloadDir: string, version: string, options: CmdOptions = { isSnapshot: false }): void {
+    const artifact = { ...ARTIFACT_TEMPLATE, version };
+    const repo = options.isSnapshot ? SNAPSHOT_REPO : RELEASE_REPO;
+    const jarFile = `${artifact.artifactId}-${artifact.version}${options.isSnapshot ? '-SNAPSHOT' : ''}-${artifact.classifier}.jar`;
+    LOGGER.info(`Download ${jarFile} from maven`);
+    download(artifact, downloadDir, repo)
+        .then(file => LOGGER.info(`Download of ${file} completed`))
+        .catch(err => {
+            LOGGER.error(err);
+            DownloadWorkflowServerCommand.error('Error occurred. Download was not successful!');
+        });
+}

--- a/dev-packages/cli/src/util/command-util.ts
+++ b/dev-packages/cli/src/util/command-util.ts
@@ -16,11 +16,9 @@
 import { Command } from 'commander';
 import * as sh from 'shelljs';
 import { configureLogger } from './logger';
-export const COMMAND_VERSION = '1.1.0-next';
 
-export function baseConfiguration(cmd: Command): Command {
-    return cmd
-        .version(COMMAND_VERSION) //
+export function baseConfiguration(cmd?: Command): Command {
+    return (cmd ?? new Command()) //
         .showSuggestionAfterError(true)
         .showHelpAfterError(true)
         .allowUnknownOption(false);

--- a/dev-packages/cli/src/util/validation-util.ts
+++ b/dev-packages/cli/src/util/validation-util.ts
@@ -24,7 +24,11 @@ export const COMMAND_VERSION = '1.1.0-next';
 export function validateDirectory(rootDir: string): string {
     const path = resolve(rootDir);
     if (!fs.existsSync(path)) {
-        throw new InvalidArgumentError('Not a valid file path!');
+        try {
+            fs.mkdirSync(path);
+        } catch (err) {
+            throw new InvalidArgumentError('Not a valid file path!');
+        }
     }
 
     if (!fs.statSync(path).isDirectory()) {
@@ -33,18 +37,30 @@ export function validateDirectory(rootDir: string): string {
     return path;
 }
 
+export function validateFile(filePath: string): string {
+    const path = resolve(filePath);
+    if (!fs.existsSync(path)) {
+        throw new InvalidArgumentError('Not a valid file path!');
+    }
+    return path;
+}
+
 export function validateVersion(version: string): string {
     LOGGER.debug(`Validate version format of: ${version}`);
     if (!semver.valid(version)) {
-        throw new Error(`Not a valid version: ${version}`);
+        throw new InvalidArgumentError('Not a valid semver version');
     }
     return version;
+}
+
+export function validateBaseVersion(version: string): string {
+    return validateVersion(version).replace(/-.*/, '');
 }
 
 export function validateGitDirectory(repository: string): string {
     const repoPath = validateDirectory(repository);
     if (!isGitRepository(repoPath)) {
-        throw new Error('Not a valid git repository');
+        throw new InvalidArgumentError('Not a valid git repository');
     }
     return repoPath;
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,16 @@
     "node": ">=14.18.0"
   },
   "scripts": {
-    "prepare": "lerna run prepare",
+    "all": "yarn install && yarn lint",
+    "build": "lerna run build",
+    "clean": "lerna run clean",
+    "lint": "lerna run lint",
+    "lint:ci": "lerna run lint:ci",
     "publish:prepare": "lerna version --ignore-scripts --yes --no-push",
     "publish:latest": "lerna publish from-git --no-git-reset --no-git-tag-version --no-verify-access --no-push",
-    "publish:next": "SHA=$(git rev-parse --short HEAD) && lerna publish preminor --exact --canary --preid next.${SHA} --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes --no-verify-access"
+    "publish:next": "SHA=$(git rev-parse --short HEAD) && lerna publish preminor --exact --canary --preid next.${SHA} --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes --no-verify-access",
+    "prepare": "lerna run prepare",
+    "test:cli": "yarn --cwd dev-packages/cli test:cli"
   },
   "devDependencies": {
     "lerna": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,6 +4050,35 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mvn-artifact-download@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-download/-/mvn-artifact-download-6.0.0.tgz#0036e6f67a45bcf20adb54447a3cfcf7abf7bc6a"
+  integrity sha512-/eIZ3/cgIm8NeE+ICq3xCvSNf3uvS7Tb/yEf8x5ACEoDcDuOwM88m2HXFUCeiqavF3irk0vWgX9VJN2tZkbqkQ==
+  dependencies:
+    mvn-artifact-filename "^6.0.0"
+    mvn-artifact-name-parser "^6.0.0"
+    mvn-artifact-url "^6.0.0"
+    node-fetch "^2.6.1"
+
+mvn-artifact-filename@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-filename/-/mvn-artifact-filename-6.0.0.tgz#bcb010f14f726371074e9af71856621baa0fb56d"
+  integrity sha512-sDHE+LMJBylCSnRZYKBVhNAslJR9fdLaRynhHVdicxgRa36+TxvHHJl+AaEje1F0VSjejRr2ab/PG7lgV9Ar5Q==
+
+mvn-artifact-name-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-name-parser/-/mvn-artifact-name-parser-6.0.0.tgz#441506503326d4633b922e3d3dd843daebfa6cc9"
+  integrity sha512-ZWnGAMB/tHREFrH/6L3M13r+xiPJtyskKTnv7rHAbNoEKrzP6E3jeaLEwNceEVqfO7Px4iowVlYijJbCdDmijw==
+
+mvn-artifact-url@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/mvn-artifact-url/-/mvn-artifact-url-6.0.0.tgz#060456cb3bd7aa82096f133534af5da0ce8dd1a9"
+  integrity sha512-OOhwPzybaBV5KH4LJ2tR6MHC9cBiPSMtbY1e/mOqJ+ZYNyr6cILktLLDWmm3R46UVzALeOqFRK0sJnMq8ixeHA==
+  dependencies:
+    mvn-artifact-filename "^6.0.0"
+    node-fetch "^2.6.1"
+    xml2js "^0.4.23"
+
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -4985,6 +5014,11 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 "semver@2 || 3 || 4 || 5", semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -5714,10 +5748,23 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- Add `download:workflowServer` command to CLI app 
-  Minor refactoring of the existing CLI code
   -  Move command definitons to the file that defines its handler
   - Ensure that commander.js validation functions throw `InvalidArgumentError`s 
   - Use version option only for root command (glsp -V) but not for subcommands
  
- Improve build scripts 
  - Remove linting from prepare step
  - Add dedicated :ci scrips for testing and linting
  - Add `all` script which 
  - Consistently sort scripts ascending 
  
 Fixes https://github.com/eclipse-glsp/glsp/issues/812
 Part of https://github.com/eclipse-glsp/glsp/issues/812