### PR TITLE
Fix bug in git util

### DIFF
--- a/dev-packages/cli/src/util/git-util.ts
+++ b/dev-packages/cli/src/util/git-util.ts
@@ -48,6 +48,7 @@ export function getUncommittedChanges(path?: string): string[] {
         .exec('git status --porcelain', getShellConfig())
         .stdout.trim()
         .split('\n')
+        .filter(value => value.trim().length !== 0)
         .map(fileInfo =>
             // Extract relative file path from the info string and convert to absolute path
             resolve(path ?? process.cwd(), fileInfo.trim().split(' ').pop() ?? '')


### PR DESCRIPTION
The `getUncommitedChanges` returned an array with one empty string for repositories with no changes. This broke the behavior of the `hasGitChanges` utility function. To avoid this we filter out empty strings.