### PR TITLE
Tweak headerCheck script

### DIFF
--- a/dev-packages/cli/src/commands/check-header.ts
+++ b/dev-packages/cli/src/commands/check-header.ts
@@ -123,7 +123,7 @@ function getFiles(rootDir: string, options: HeaderCheckOptions): string[] {
     excludePattern.forEach(pattern => {
         changedFiles = changedFiles.filter(minimatch.filter(`!${pattern}`));
     });
-    return changedFiles;
+    return changedFiles.filter(file => fs.existsSync(file));
 }
 
 function validate(rootDir: string, files: string[], options: HeaderCheckOptions): ValidationResult[] {


### PR DESCRIPTION
When using the `lastCommit` or `changes` target the header check might be executed for files that no longer exist (i.e. have been deleted as part of the commit/change). This can be avoided by filtering out non-existent files before validating.