### PR TITLE
Align eslint rules for deprecation

### DIFF
--- a/dev-packages/eslint-config/configs/errors.eslintrc.js
+++ b/dev-packages/eslint-config/configs/errors.eslintrc.js
@@ -74,7 +74,6 @@ module.exports = {
         ],
         // eslint-plugin-import
         'import/export': 'off', // we have multiple exports due to namespaces, enums and classes that share the same name
-        'import/no-deprecated': 'error',
         // eslint-plugin-no-null
         'no-null/no-null': 'error',
         // chai friendly

--- a/dev-packages/eslint-config/configs/warnings.eslintrc.js
+++ b/dev-packages/eslint-config/configs/warnings.eslintrc.js
@@ -78,6 +78,7 @@ module.exports = {
         '@typescript-eslint/no-this-alias': 'off',
 
         /// eslint-plugin-deprecation plugin
+        'import/no-deprecated': 'warn',
         'deprecation/deprecation': 'warn'
     }
 };


### PR DESCRIPTION
We had two rules for deprecation in place. One produced and error the other one a warning. Align both rules at "warn" level