### PR TITLE
Update release script

### DIFF
--- a/dev-packages/cli/src/commands/release/common.ts
+++ b/dev-packages/cli/src/commands/release/common.ts
@@ -134,8 +134,8 @@ export function checkoutAndCd(options: ReleaseOptions): string {
     sh.exec(`gh repo clone ${ghUrl}`, getShellConfig());
     LOGGER.debug(`Successfully cloned to ${directory}`);
     sh.cd(directory);
-    if (options.checkoutDir !== 'master') {
-        sh.exec(`git switch ${options.branch} `);
+    if (options.branch !== 'master' && options.branch !== 'main') {
+        sh.exec(`git checkout ${options.branch} `);
     }
     return sh.pwd();
 }


### PR DESCRIPTION
- Ensure that script works for both `master` and `main` naming conventions
- Use git checkout over `git switch` because switch is not available in all git installations