### PR TITLE
GLSP-813: Update release scripts

### DIFF
--- a/dev-packages/cli/src/commands/release/common.ts
+++ b/dev-packages/cli/src/commands/release/common.ts
@@ -257,8 +257,8 @@ export function asMvnVersion(version: string): string {
     return mavenVersion;
 }
 
-export async function checkIfNpmVersionExists(pckgName: string, newVersion: string): Promise<void> {
-    LOGGER.debug(`Check if version exists on npm: ${newVersion}`);
+export async function checkIfNpmVersionIsNew(pckgName: string, newVersion: string): Promise<void> {
+    LOGGER.debug(`Check that the release version is new i.e. does not exist on npm: ${newVersion}`);
 
     const response = await fetch(`https://registry.npmjs.org/${pckgName}/${newVersion}`);
     const data = await response.json();

--- a/dev-packages/cli/src/commands/release/release-client.ts
+++ b/dev-packages/cli/src/commands/release/release-client.ts
@@ -16,15 +16,13 @@
 import * as sh from 'shelljs';
 import { LOGGER } from '../../util/logger';
 import {
-    asMvnVersion,
-    checkJavaServerVersion,
     checkoutAndCd,
     commitAndTag,
     lernaSetVersion,
     publish,
     ReleaseOptions,
     updateLernaForDryRun,
-    updateServerConfig,
+    updateVersion,
     yarnInstall
 } from './common';
 
@@ -34,7 +32,7 @@ export async function releaseClient(options: ReleaseOptions): Promise<void> {
     LOGGER.info('Prepare glsp-client release');
     LOGGER.debug('Release options: ', options.version);
     REPO_ROOT = checkoutAndCd(options);
-    await updateDownloadServerScript(options.version, options.force);
+    updateExternalGLSPDependencies(options.version);
     generateChangeLog();
     lernaSetVersion(REPO_ROOT, options.version);
     build();
@@ -45,12 +43,10 @@ export async function releaseClient(options: ReleaseOptions): Promise<void> {
     publish(REPO_ROOT, options);
 }
 
-async function updateDownloadServerScript(version: string, force: boolean): Promise<void> {
-    LOGGER.info('Update example server download config');
-    const mvnVersion = asMvnVersion(version);
-    checkJavaServerVersion(version, force);
-    sh.cd(`${REPO_ROOT}/examples/workflow-glsp/scripts`);
-    updateServerConfig('config.json', mvnVersion, false);
+function updateExternalGLSPDependencies(version: string): void {
+    LOGGER.info('Update external GLSP dependencies (workflow example server)');
+    sh.cd(REPO_ROOT);
+    updateVersion({ name: '@eclipse-glsp-examples/workflow-server', version });
 }
 
 function generateChangeLog(): void {

--- a/dev-packages/cli/src/commands/release/release-theia-integration.ts
+++ b/dev-packages/cli/src/commands/release/release-theia-integration.ts
@@ -17,15 +17,12 @@
 import * as sh from 'shelljs';
 import { LOGGER } from '../../util/logger';
 import {
-    asMvnVersion,
     checkoutAndCd,
     commitAndTag,
-    isExistingMavenVersion,
     lernaSetVersion,
     publish,
     ReleaseOptions,
     updateLernaForDryRun,
-    updateServerConfig,
     updateVersion,
     yarnInstall
 } from './common';
@@ -37,7 +34,6 @@ export async function releaseTheiaIntegration(options: ReleaseOptions): Promise<
     LOGGER.debug('Release options: ', options);
     REPO_ROOT = checkoutAndCd(options);
     updateExternalGLSPDependencies(options.version);
-    await updateDownloadServerScript(options.version);
     generateChangeLog();
     lernaSetVersion(REPO_ROOT, options.version);
     build();
@@ -49,21 +45,13 @@ export async function releaseTheiaIntegration(options: ReleaseOptions): Promise<
 }
 
 function updateExternalGLSPDependencies(version: string): void {
-    LOGGER.info('Update external GLSP dependencies (Client and workflow example)');
+    LOGGER.info('Update external GLSP dependencies (Client and workflow example & server)');
     sh.cd(REPO_ROOT);
-    updateVersion({ name: '@eclipse-glsp/client', version }, { name: '@eclipse-glsp-examples/workflow-glsp', version });
-}
-
-async function updateDownloadServerScript(version: string): Promise<void> {
-    LOGGER.info('Update example server download config');
-    const mvnVersion = asMvnVersion(version);
-    if (!isExistingMavenVersion('org.eclipse.glsp', 'org.eclipse.glsp.server', mvnVersion)) {
-        LOGGER.warn(`No Java GLSP server with version ${mvnVersion} found on maven central!. Please release a new Java GLSP Server version
-        before publishing this release!`);
-    }
-
-    sh.cd(`${REPO_ROOT}/examples/workflow-theia/src/node`);
-    updateServerConfig('server-config.json', mvnVersion, false);
+    updateVersion(
+        { name: '@eclipse-glsp/client', version },
+        { name: '@eclipse-glsp-examples/workflow-glsp', version },
+        { name: '@eclipse-glsp-examples/workflow-server', version }
+    );
 }
 
 function build(): void {

--- a/dev-packages/cli/src/commands/release/release-vscode-integration.ts
+++ b/dev-packages/cli/src/commands/release/release-vscode-integration.ts
@@ -50,7 +50,8 @@ function updateExternalGLSPDependencies(version: string): void {
     updateVersion(
         { name: '@eclipse-glsp/protocol', version },
         { name: '@eclipse-glsp/client', version },
-        { name: '@eclipse-glsp-examples/workflow-glsp', version }
+        { name: '@eclipse-glsp-examples/workflow-glsp', version },
+        { name: '@eclipse-glsp-examples/workflow-server', version }
     );
 }
 

--- a/dev-packages/cli/src/commands/release/release.ts
+++ b/dev-packages/cli/src/commands/release/release.ts
@@ -21,16 +21,16 @@ import * as readline from 'readline-sync';
 import * as semver from 'semver';
 import * as sh from 'shelljs';
 import { baseCommand, configureShell, fatalExec, getShellConfig } from '../../util/command-util';
-import { configureLogger, LOGGER } from '../../util/logger';
+import { LOGGER, configureLogger } from '../../util/logger';
 import { validateDirectory, validateVersion } from '../../util/validation-util';
 import {
-    asMvnVersion,
-    checkIfMavenVersionExists,
-    checkIfNpmVersionExists,
     Component,
     ReleaseOptions,
     ReleaseType,
-    VERDACCIO_REGISTRY
+    VERDACCIO_REGISTRY,
+    asMvnVersion,
+    checkIfMavenVersionExists,
+    checkIfNpmVersionIsNew
 } from './common';
 import { releaseClient } from './release-client';
 import { releaseEclipseIntegration } from './release-eclipse-integration';
@@ -91,19 +91,19 @@ export async function release(
                 checkIfMavenVersionExists('org.eclipse.glsp', 'org.eclipse.glsp.server', asMvnVersion(version));
                 return releaseJavaServer(options);
             case 'server-node':
-                await checkIfNpmVersionExists('@eclipse-glsp/server-node', version);
+                await checkIfNpmVersionIsNew('@eclipse-glsp/server-node', version);
                 return releaseServerNode(options);
             case 'client':
-                await checkIfNpmVersionExists('@eclipse-glsp/client', version);
+                await checkIfNpmVersionIsNew('@eclipse-glsp/client', version);
                 return releaseClient(options);
             case 'theia-integration':
-                await checkIfNpmVersionExists('@eclipse-glsp/theia-integration', version);
+                await checkIfNpmVersionIsNew('@eclipse-glsp/theia-integration', version);
                 return releaseTheiaIntegration(options);
             case 'vscode-integration':
-                await checkIfNpmVersionExists('@eclipse-glsp/vscode-integration', version);
+                await checkIfNpmVersionIsNew('@eclipse-glsp/vscode-integration', version);
                 return releaseVscodeIntegration(options);
             case 'eclipse-integration':
-                await checkIfNpmVersionExists('@eclipse-glsp/ide', version);
+                await checkIfNpmVersionIsNew('@eclipse-glsp/ide', version);
                 return releaseEclipseIntegration(options);
         }
     } catch (err) {


### PR DESCRIPTION
The embedded example servers are now node based therefore:  Remove function to update the java-server-download script from component release functions. Ensure that the used version of `@eclipse-glsp-examples/workflow-server` is updated as part of the release functions

Closes https://github.com/eclipse-glsp/glsp/issues/813

@martin-fleck-at Please use this PR for the RC publishing this week and approve if everything works