### PR TITLE
Fix release scripts

### DIFF
--- a/dev-packages/cli/src/commands/release/common.ts
+++ b/dev-packages/cli/src/commands/release/common.ts
@@ -43,7 +43,7 @@ export interface ReleaseOptions {
 export type ReleaseRepository = 'npm' | 'm2' | 'm2&p2' | 'p2';
 
 export interface Component {
-    type: (typeof Component.CLI_CHOICES)[number];
+    type: typeof Component.CLI_CHOICES[number];
     releaseRepo: ReleaseRepository;
     githubRepo: string;
     directory: string;
@@ -114,7 +114,7 @@ export namespace ReleaseType {
     export const CLI_CHOICES = ['major', 'minor', 'patch', 'rc', 'custom'] as const;
 }
 
-export type ReleaseType = (typeof ReleaseType.CLI_CHOICES)[number];
+export type ReleaseType = typeof ReleaseType.CLI_CHOICES[number];
 
 export function checkoutAndCd(options: ReleaseOptions): string {
     const ghUrl = options.component.githubRepo;
@@ -186,7 +186,7 @@ function doPublish(tag: string, preRelease: boolean, latestRelease: string, draf
     fatalExec(`git push origin HEAD:${tag}`, 'Could not push release branch to Github', getShellConfig({ silent: false }));
     fatalExec(`git push origin tag ${tag}`, 'Could not push tag to Github', getShellConfig({ silent: false }));
     const version = tagToVersion(tag);
-    const titleSuffix = preRelease ? ` Candiate ${version.substring(version.lastIndexOf('-RC')) + 3}` : '';
+    const titleSuffix = preRelease ? ` Candidate ${version.substring(version.lastIndexOf('-RC') + 3)}` : '';
     const title = `${version.replace(/-.*/, '')} Release${titleSuffix} `;
     sh.exec(
         `gh release create ${tag} -t "${title}" --notes-start-tag ${latestRelease} --generate-notes ${draft ? '-d' : ''} ${

--- a/dev-packages/cli/src/commands/release/common.ts
+++ b/dev-packages/cli/src/commands/release/common.ts
@@ -43,7 +43,7 @@ export interface ReleaseOptions {
 export type ReleaseRepository = 'npm' | 'm2' | 'm2&p2' | 'p2';
 
 export interface Component {
-    type: typeof Component.CLI_CHOICES[number];
+    type: (typeof Component.CLI_CHOICES)[number];
     releaseRepo: ReleaseRepository;
     githubRepo: string;
     directory: string;
@@ -114,7 +114,7 @@ export namespace ReleaseType {
     export const CLI_CHOICES = ['major', 'minor', 'patch', 'rc', 'custom'] as const;
 }
 
-export type ReleaseType = typeof ReleaseType.CLI_CHOICES[number];
+export type ReleaseType = (typeof ReleaseType.CLI_CHOICES)[number];
 
 export function checkoutAndCd(options: ReleaseOptions): string {
     const ghUrl = options.component.githubRepo;
@@ -186,7 +186,7 @@ function doPublish(tag: string, preRelease: boolean, latestRelease: string, draf
     fatalExec(`git push origin HEAD:${tag}`, 'Could not push release branch to Github', getShellConfig({ silent: false }));
     fatalExec(`git push origin tag ${tag}`, 'Could not push tag to Github', getShellConfig({ silent: false }));
     const version = tagToVersion(tag);
-    const titleSuffix = preRelease ? ` Candiate ${version.substring(version.length - 1)}` : '';
+    const titleSuffix = preRelease ? ` Candiate ${version.substring(version.lastIndexOf('-RC')) + 3}` : '';
     const title = `${version.replace(/-.*/, '')} Release${titleSuffix} `;
     sh.exec(
         `gh release create ${tag} -t "${title}" --notes-start-tag ${latestRelease} --generate-notes ${draft ? '-d' : ''} ${

--- a/dev-packages/cli/src/commands/release/release-client.ts
+++ b/dev-packages/cli/src/commands/release/release-client.ts
@@ -46,7 +46,7 @@ export async function releaseClient(options: ReleaseOptions): Promise<void> {
 function updateExternalGLSPDependencies(version: string): void {
     LOGGER.info('Update external GLSP dependencies (workflow example server)');
     sh.cd(REPO_ROOT);
-    updateVersion({ name: '@eclipse-glsp-examples/workflow-server', version });
+    updateVersion({ name: '@eclipse-glsp-examples/workflow-server-bundled', version });
 }
 
 function generateChangeLog(): void {

--- a/dev-packages/cli/src/commands/release/release.ts
+++ b/dev-packages/cli/src/commands/release/release.ts
@@ -134,7 +134,7 @@ function isGithubCLIAuthenticated(): boolean {
         }
         throw new Error(status.stderr);
     }
-    if (!status.stderr.trim().includes('Logged in to github.com')) {
+    if (!status.stdout.trim().includes('Logged in to github.com')) {
         LOGGER.debug("No user is logged in for host 'github.com'");
         return false;
     }

--- a/glsp.theia.code-workspace
+++ b/glsp.theia.code-workspace
@@ -13,10 +13,8 @@
             "path": "../glsp-theia-integration"
         },
         {
+            "name": "glsp-server-node",
             "path": "../glsp-server-node"
-        },
-        {
-            "path": "../../sprotty/sprotty"
         }
     ],
     "settings": {


### PR DESCRIPTION
- Use correct output channel in isGithubCLIAuthenticated() helper function
- Update client release script to use the correct workflow server package
- Fix extraction of wrong version number for github releases