### PR TITLE
Update tsconfig

### DIFF
--- a/dev-packages/ts-config/tsconfig.json
+++ b/dev-packages/ts-config/tsconfig.json
@@ -19,7 +19,7 @@
     "emitDecoratorMetadata": true,
     "downlevelIteration": true,
     "resolveJsonModule": true,
-    "module": "commonjs",
+    "module": "Node16",
     "moduleResolution": "Node16",
     "target": "ES2017",
     "jsx": "react",


### PR DESCRIPTION
Update `module` property in the tsconfig package to `Node16`.
Reason: Newer Typescript 5 versions are complaining with the following error otherwise:

```
@eclipse-glsp/ide: error TS5110: Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16.
```