### PR TITLE
Refactor `check-header` script

### DIFF
--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/cli",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "CLI Tooling & scripts for GLSP components",
   "keywords": [
     "eclipse",
@@ -49,7 +49,7 @@
     "shelljs": "^0.8.5"
   },
   "devDependencies": {
-    "@eclipse-glsp/config": "~2.0.0",
+    "@eclipse-glsp/config": "2.2.0-next",
     "@types/glob": "^8.1.0",
     "@types/node-fetch": "^2.6.6",
     "@types/readline-sync": "^1.4.5",

--- a/dev-packages/cli/src/commands/release/release-vscode-integration.ts
+++ b/dev-packages/cli/src/commands/release/release-vscode-integration.ts
@@ -51,7 +51,8 @@ function updateExternalGLSPDependencies(version: string): void {
         { name: '@eclipse-glsp/protocol', version },
         { name: '@eclipse-glsp/client', version },
         { name: '@eclipse-glsp-examples/workflow-glsp', version },
-        { name: '@eclipse-glsp-examples/workflow-server', version }
+        { name: '@eclipse-glsp-examples/workflow-server', version },
+        { name: '@eclipse-glsp-examples/workflow-server-bundled', version }
     );
 }
 

--- a/dev-packages/cli/src/util/git-util.ts
+++ b/dev-packages/cli/src/util/git-util.ts
@@ -84,28 +84,6 @@ export function getLastModificationDate(filePath?: string, repoRoot?: string, ex
     }
     return new Date(result.stdout.trim());
 }
-/**
- * Returns the last modification date of a file in a git repo.
- * @param filePath The file
- * @param repoRoot The path to the repo root. If undefined the current working directory is used.
- * @param excludeMessage Only consider commits that don`t match the excludeMessage
- * @returns The date or undefined if the file is outside of the git repo.
- */
-export function getFirstModificationDate(filePath: string, repoRoot?: string, excludeMessage?: string): Date | undefined {
-    cdIfPresent(repoRoot);
-    const additionalArgs = excludeMessage ? `--grep="${excludeMessage}" --invert-grep` : '';
-    const result = sh.exec(`git log ${additionalArgs} --pretty="format:%ci" --follow ${filePath}`, getShellConfig());
-    if (result.code !== 0) {
-        return undefined;
-    }
-    const datesString = result.stdout.trim();
-    if (datesString.length === 0) {
-        return new Date();
-    }
-
-    const date = datesString.split('\n').pop();
-    return date ? new Date(date) : undefined;
-}
 
 export function getFilesOfCommit(commitHash: string, repoRoot?: string): string[] {
     cdIfPresent(repoRoot);
@@ -115,38 +93,6 @@ export function getFilesOfCommit(commitHash: string, repoRoot?: string): string[
     }
 
     return result.stdout.trim().split('\n');
-}
-
-/**
- * Returns the commit hash of the initial commit of the given repository
- * @param repoRoot The path to the repo root. If undefined the current working directory is used.
- * @returns The commit hash or undefined if something went wrong.
- */
-export function getInitialCommit(repoRoot?: string): string | undefined {
-    cdIfPresent(repoRoot);
-    const result = sh.exec('git log --pretty=oneline --reverse', getShellConfig());
-    if (result.code !== 0) {
-        return undefined;
-    }
-    const commits = result.stdout.trim();
-    if (commits.length === 0) {
-        return undefined;
-    }
-    return commits.substring(0, commits.indexOf(' '));
-}
-
-/**
- * Returns the commit hash of the first commit for a given file (across renames).
- * @param repoRoot The path to the repo root. If undefined the current working directory is used.
- * @returns The commit hash or undefined if something went wrong.
- */
-export function getFirstCommit(filePath: string, repoRoot?: string): string | undefined {
-    cdIfPresent(repoRoot);
-    const result = sh.exec(`git log --follow  --pretty=format:"%H" ${filePath}`, getShellConfig());
-    if (result.code !== 0) {
-        return undefined;
-    }
-    return result.stdout.trim().split('\n').pop();
 }
 
 export function getLatestGithubRelease(path?: string): string {

--- a/dev-packages/config-test/package.json
+++ b/dev-packages/config-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/config-test",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Meta package that provides Mocha and nyc configurations for GLSP projects",
   "keywords": [
     "eclipse",
@@ -25,8 +25,8 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/mocha-config": "~2.0.0",
-    "@eclipse-glsp/nyc-config": "~2.0.0",
+    "@eclipse-glsp/mocha-config": "2.2.0-next",
+    "@eclipse-glsp/nyc-config": "2.2.0-next",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.7",
     "@types/mocha": "^10.0.2",

--- a/dev-packages/config/package.json
+++ b/dev-packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Meta package that provides Typescript, eslint and prettier configurations and common dev dependencies for GLSP projects",
   "keywords": [
     "eclipse",
@@ -24,9 +24,9 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/eslint-config": "~2.0.0",
-    "@eclipse-glsp/prettier-config": "~2.0.0",
-    "@eclipse-glsp/ts-config": "~2.0.0",
+    "@eclipse-glsp/eslint-config": "2.2.0-next",
+    "@eclipse-glsp/prettier-config": "2.2.0-next",
+    "@eclipse-glsp/ts-config": "2.2.0-next",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
     "eslint": "^8.51.0",

--- a/dev-packages/dev/package.json
+++ b/dev-packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/dev",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "All-in-one meta package that provides the GLSP development and test configuration packages, as well as  the GLSP CLI package",
   "keywords": [
     "eclipse",
@@ -24,9 +24,9 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/cli": "~2.0.0",
-    "@eclipse-glsp/config": "~2.0.0",
-    "@eclipse-glsp/config-test": "~2.0.0"
+    "@eclipse-glsp/cli": "2.2.0-next",
+    "@eclipse-glsp/config": "2.2.0-next",
+    "@eclipse-glsp/config-test": "2.2.0-next"
   },
   "publishConfig": {
     "access": "public"

--- a/dev-packages/eslint-config/package.json
+++ b/dev-packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/eslint-config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Shared ESLint configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/mocha-config/package.json
+++ b/dev-packages/mocha-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/mocha-config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Shared Mocha test configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/nyc-config/package.json
+++ b/dev-packages/nyc-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/nyc-config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Shared nyc configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/prettier-config/package.json
+++ b/dev-packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/prettier-config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Shared Prettier configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/ts-config/package.json
+++ b/dev-packages/ts-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/ts-config",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "description": "Shared Typescript configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.0.0",
+  "version": "2.2.0-next",
   "private": true,
   "workspaces": [
     "dev-packages/*"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Refactor check header script to only consider the `endYear` in copyrigh headers. Previously we also had a mechanism in place to validate the start year of a copyright range. However, this approach was flawed because
- It could not consider files that predate the initial inception of the repository
- had a hard time with determining  the correct start year for files that have been renamed/moved

So in the end we opted for ignoring startYear validations anyways and only considered endYear errors. Therefore this PR removes the entire `startYear` validation and we only check for single year or end year violations. This makes the whole check process faster and less error prone.

In addition, there was an issue with files that had multiple copyright years defined (e.g. `contribution-provider` in glsp-client). This is now fixed.

In addition, align version numbers with the other GLSP projects so that the dev-packages can be included in the Release train.

Also: Minor fix for `release-vscode-integration`

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
