### PR TITLE
Revert "V2.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Eclipse GLSP Dev Packages Changelog
 
-## 2.2.0 - 04/07/2024
-
--   Contribute the `generateIndex` command to the GLSP CLI. Allows autogeneration of index files in GLSP projects. [#1197](https://github.com/eclipse-glsp/glsp/pull/1197)
--   Fix version updating of example servers in `release` CLI command. [#1226](https://github.com/eclipse-glsp/glsp/pull/1226)
--   Refactor and simplify `checkHeader` CLI command. Focus on end year copyright header validation and remove the error-prone validation of the start year. [#1289](https://github.com/eclipse-glsp/glsp/pull/1289)
--   Contribute the `updateNext` command to the GLSP CLI tool. Allows updating of all dependencies in GLSP projects that are tagged with `next´. [1229](https://github.com/eclipse-glsp/glsp/pull/1299)
-
 ## 2.0.0 - 13/10/2023
 
 -   [config] Update all dependencies & peerDependencies of the dev to the latest version [#1136](https://github.com/eclipse-glsp/glsp/pull/1136)
@@ -17,10 +10,12 @@
 -   [cli] Contribute the `checkHeaders` command to validate the copyright year (range) of license headers. [#834](https://github.com/eclipse-glsp/glsp/pull/834)
 -   [config] Introduce [`@eclipse-glsp/nyc-config`](https://www.npmjs.com/package/@eclipse-glsp/nyc-config)
     package and the [`@eclipse-glsp/config-test`](https://www.npmjs.com/package/@eclipse-glsp/config-test) meta package. [#755](https://github.com/eclipse-glsp/glsp/pull/755)
--   Contribute the `coverageReport` command to create a full nyc test coverage report for a lerna/yarn mono repository
+
+    -   Contribute the `coverageReport` command to create a full nyc test coverage report for a lerna/yarn mono repository
+
 -   [cli] Introduce [`@eclipse-glsp/cli`](https://www.npmjs.com/package/@eclipse-glsp/cli)
     package to offer CLI tooling & utility scripts for GLSP projects. [#755](https://github.com/eclipse-glsp/glsp/pull/755) - Contributed on behalf of STMicroelectronics
--   Contribute the `release` command to prepare & publish a new Github release for a specific GLSP component
+    -   Contribute the `release` command to prepare & publish a new Github release for a specific GLSP component
 -   [deps] Updates dependencies of `@eclipse-glsp/config` and `@eclipse-glsp/config-test` packages to the latest version [#1023](https://github.com/eclipse-glsp/glsp/pull/1023)
 
 ### Breaking Changes

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/cli",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "CLI Tooling & scripts for GLSP components",
   "keywords": [
     "eclipse",
@@ -50,7 +50,7 @@
     "shelljs": "^0.8.5"
   },
   "devDependencies": {
-    "@eclipse-glsp/config": "2.2.0",
+    "@eclipse-glsp/config": "2.2.0-next",
     "@types/glob": "^8.1.0",
     "@types/node-fetch": "^2.6.6",
     "@types/readline-sync": "^1.4.5",

--- a/dev-packages/cli/src/app.ts
+++ b/dev-packages/cli/src/app.ts
@@ -1,5 +1,6 @@
+#!/usr/bin/env node
 /********************************************************************************
- * Copyright (c) 2022-2024 EclipseSource and others.
+ * Copyright (c) 2022 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/dev-packages/config-test/package.json
+++ b/dev-packages/config-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/config-test",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Meta package that provides Mocha and nyc configurations for GLSP projects",
   "keywords": [
     "eclipse",
@@ -25,8 +25,8 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/mocha-config": "2.2.0",
-    "@eclipse-glsp/nyc-config": "2.2.0",
+    "@eclipse-glsp/mocha-config": "2.2.0-next",
+    "@eclipse-glsp/nyc-config": "2.2.0-next",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.7",
     "@types/mocha": "^10.0.2",

--- a/dev-packages/config/package.json
+++ b/dev-packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Meta package that provides Typescript, eslint and prettier configurations and common dev dependencies for GLSP projects",
   "keywords": [
     "eclipse",
@@ -24,9 +24,9 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/eslint-config": "2.2.0",
-    "@eclipse-glsp/prettier-config": "2.2.0",
-    "@eclipse-glsp/ts-config": "2.2.0",
+    "@eclipse-glsp/eslint-config": "2.2.0-next",
+    "@eclipse-glsp/prettier-config": "2.2.0-next",
+    "@eclipse-glsp/ts-config": "2.2.0-next",
     "@typescript-eslint/eslint-plugin": "^6.7.5",
     "@typescript-eslint/parser": "^6.7.5",
     "eslint": "^8.51.0",

--- a/dev-packages/dev/package.json
+++ b/dev-packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/dev",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "All-in-one meta package that provides the GLSP development and test configuration packages, as well as  the GLSP CLI package",
   "keywords": [
     "eclipse",
@@ -24,9 +24,9 @@
     }
   ],
   "dependencies": {
-    "@eclipse-glsp/cli": "2.2.0",
-    "@eclipse-glsp/config": "2.2.0",
-    "@eclipse-glsp/config-test": "2.2.0"
+    "@eclipse-glsp/cli": "2.2.0-next",
+    "@eclipse-glsp/config": "2.2.0-next",
+    "@eclipse-glsp/config-test": "2.2.0-next"
   },
   "publishConfig": {
     "access": "public"

--- a/dev-packages/eslint-config/package.json
+++ b/dev-packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/eslint-config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Shared ESLint configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/mocha-config/package.json
+++ b/dev-packages/mocha-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/mocha-config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Shared Mocha test configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/nyc-config/package.json
+++ b/dev-packages/nyc-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/nyc-config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Shared nyc configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/prettier-config/package.json
+++ b/dev-packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/prettier-config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Shared Prettier configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/dev-packages/ts-config/package.json
+++ b/dev-packages/ts-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/ts-config",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Shared Typescript configuration for GLSP projects",
   "keywords": [
     "eclipse",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "private": true,
   "workspaces": [
     "dev-packages/*"
@@ -18,7 +18,7 @@
     "prepare": "yarn build",
     "publish:latest": "lerna publish from-git --no-git-reset --no-git-tag-version --no-verify-access --no-push",
     "publish:next": "lerna publish preminor --exact --canary --preid next --dist-tag next --no-git-reset --no-git-tag-version --no-push --ignore-scripts --yes",
-    "publish:prepare": "lerna version --ignore-scripts --yes --no-push --exact --no-git-tag-version",
+    "publish:prepare": "lerna version --ignore-scripts --yes --no-push",
     "start:cli": " yarn --cwd dev-packages/cli start",
     "watch": "tsc -b -w --preserveWatchOutput"
   },


### PR DESCRIPTION
Reverts eclipse-glsp/glsp#1359
Due to a bug discovered during the release process its necessary to revert the currently ongoing 2.2.0 release.
Already published artifacts will be removed/ unpublished
and a clean 2.2.1 release will be published