### PR TITLE
GLSP-1563: Update to node 20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ kind: Pod
 spec:
   containers:
   - name: node
-    image: eclipseglsp/ci:alpine-v5.0
+    image: eclipseglsp/ci:alpine-v6.0
     tty: true
     resources:
       limits:

--- a/dev-packages/ts-config/tsconfig.json
+++ b/dev-packages/ts-config/tsconfig.json
@@ -20,7 +20,7 @@
     "downlevelIteration": true,
     "resolveJsonModule": true,
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "node16",
     "target": "ES2019",
     "jsx": "react",
     "lib": ["ES2019", "dom"],

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ They are mainly used for CI jobs that require the possibility to build client an
 Currently each image variant has at least the following components installed:
 
 -   Git >=2.17.1
--   Node 18, yarn 1.22.4 and lerna
+-   Node 20, yarn 1.22.4 and lerna
 -   OpenJDK 17 and Maven >=3.6.0
 -   Python and GCC libraries to enable [Theia](https://theia-ide.org/) builds
 

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -13,10 +13,10 @@
 
 ## Supported tags and respective `Dockerfile` links
 
--   [`latest`, `ubuntu`, `ubuntu-v5.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/ubuntu/Dockerfile)
--   [`uitest`,`uitest-v5.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/uitest/Dockerfile)
+-   [`latest`, `ubuntu`, `ubuntu-v6.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/ubuntu/Dockerfile)
+-   [`uitest`,`uitest-v6.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/uitest/Dockerfile)
 
--   [`alpine`, `alpine-v5.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/alpine/Dockerfile)
+-   [`alpine`, `alpine-v6.0`](https://github.com/eclipse-glsp/glsp/blob/master/docker/ci/alpine/Dockerfile)
 
 Note that these tags are fluent and not bound to a fixed image version.
 If you want to use a fixed version you can use the base tag with a version suffix e.g. `ubuntu-v1.0`.
@@ -34,7 +34,7 @@ They are mainly used for CI jobs that require the possibility to build client an
 Currently each image variant has at least the following components installed:
 
 -   Git >=2.17.1
--   Node 18, yarn 1.22.19 and lerna
+-   Node 20, yarn 1.22.19 and lerna
 -   OpenJDK 17 and Maven >=3.6.0
 -   Python and GCC libraries to enable [Theia](https://theia-ide.org/) builds
 
@@ -82,6 +82,7 @@ In addition, Google Chrome is installed which enables browser-based UI testing o
 -   [v3.1](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v3.1): Pre-install latest lerna version
 -   [v4.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v4.0): Update to node 16
 -   [v5.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v5.0): Update to node 18, Java 17 and Alpine 3.17/Ubuntu 22.04
+-   [v5.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v6.0): Update to node 20
 
 ## License
 

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -82,7 +82,7 @@ In addition, Google Chrome is installed which enables browser-based UI testing o
 -   [v3.1](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v3.1): Pre-install latest lerna version
 -   [v4.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v4.0): Update to node 16
 -   [v5.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v5.0): Update to node 18, Java 17 and Alpine 3.17/Ubuntu 22.04
--   [v5.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v6.0): Update to node 20
+-   [v6.0](https://hub.docker.com/r/eclipseglsp/ci/tags?page=1&name=v6.0): Update to node 20
 
 ## License
 

--- a/docker/ci/alpine/Dockerfile
+++ b/docker/ci/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # eclipseglsp/ci:alpine
-# 5.0
-FROM node:18-alpine3.17
+# 6.0
+FROM node:20-alpine3.22
 
 # Install Java, Maven, Git and dependecies for Theia
 ENV JAVA_HOME="/usr/lib/jvm/default-jvm/"

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 # eclipseglsp/ci:ubuntu
-# 5.0
+# 6.0
 FROM ubuntu:22.04 
 # Install node & other Theia related dependencies
 RUN apt-get update && \
@@ -10,6 +10,6 @@ RUN apt-get update && \
     libsecret-1-dev \
     build-essential libssl-dev rsync -y && \
     #Install node
-    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install nodejs -y && \
     npm install -g yarn lerna

--- a/docker/ci/uitest/Dockerfile
+++ b/docker/ci/uitest/Dockerfile
@@ -1,5 +1,5 @@
 # eclipseglsp/ci:uitest
-# 5.0
+# 6.0
 FROM ubuntu:22.04
 # Install node & other Theia related dependencies
 RUN apt-get update && \
@@ -10,7 +10,7 @@ RUN apt-get update && \
     libsecret-1-dev \
     build-essential libssl-dev rsync -y && \
     #Install node
-    curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install nodejs -y && \
     npm install -g yarn lerna &&\
     apt-get install lsof xvfb -y

--- a/package.json
+++ b/package.json
@@ -1,24 +1,20 @@
 {
   "name": "parent",
-  "version": "2.5.0-next",
   "private": true,
   "workspaces": [
     "dev-packages/*"
   ],
   "scripts": {
-    "all": "yarn install && yarn lint",
     "build": "yarn compile",
     "check:headers": "yarn start:cli checkHeaders . -t lastCommit",
-    "check:pr": "yarn all && yarn check:headers",
+    "check:pr": "yarn install && yarn lint && yarn check:headers",
     "clean": "lerna run clean",
     "compile": "tsc -b",
     "lint": "eslint --ext .ts,.tsx .",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "lint:fix": "yarn lint --fix",
     "prepare": "yarn build",
-    "publish:latest": "lerna publish from-git --no-verify-access --no-push",
     "publish:next": "lerna publish preminor --exact --canary --preid next --dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes",
-    "publish:prepare": "lerna version --ignore-scripts --yes --no-push --exact",
     "start:cli": " yarn --cwd dev-packages/cli start",
     "watch": "tsc -b -w --preserveWatchOutput"
   },
@@ -26,7 +22,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
-    "@types/node": "18.x",
+    "@types/node": "20.x",
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
@@ -48,10 +44,10 @@
     "rimraf": "^5.0.1",
     "sinon": "^15.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "yarn": ">=1.7.0 <2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,12 +1061,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@18.x":
-  version "18.19.68"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.68.tgz#f4f10d9927a7eaf3568c46a6d739cc0967ccb701"
-  integrity sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==
+"@types/node@20.x":
+  version "20.19.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.11.tgz#728cab53092bd5f143beed7fbba7ba99de3c16c4"
+  integrity sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -7329,10 +7329,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.0.4:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -7361,6 +7361,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Update minimum node version requirement to node 20
Update ci docker images
Update Jenkinsfile

Also clean up scripts in root package.json (Remove no longer needed
publish scripts and all script)

Part of: https://github.com/eclipse-glsp/glsp/issues/1563