### PR TITLE
Fix bug in update-next cli

### DIFF
--- a/dev-packages/cli/src/commands/update-next.ts
+++ b/dev-packages/cli/src/commands/update-next.ts
@@ -50,7 +50,7 @@ export async function updateNext(rootDir: string, options: { verbose: boolean })
 
     LOGGER.info('Updating next dependencies ...');
     rootDir = path.resolve(rootDir);
-    const packages = getYarnWorkspacePackages(rootDir);
+    const packages = getYarnWorkspacePackages(rootDir, true);
     LOGGER.debug(`Scanning ${packages.length} packages to derive resolutions`, packages);
     const resolutions = await getResolutions(packages);
     if (Object.keys(resolutions).length === 0) {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

When scanning for "next" version in the package dependencies the root package itself was not included on accident.
This caused incorrect upgrade `@eclipse-glsp/dev` in root devDependencies.
The yarnYarnWorkspacePackages helper function has an optiona `includeRoot` flag which neeed to be set to true
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
