### PR TITLE
GLSP-1654: add `glsp repo` command 

### DIFF
--- a/dev-packages/cli/.mocharc.e2e.json
+++ b/dev-packages/cli/.mocharc.e2e.json
@@ -2,5 +2,7 @@
   "$schema": "https://json.schemastore.org/mocharc",
   "extends": "@eclipse-glsp/mocha-config",
   "spec": ["./tests/e2e/**/*.e2e.spec.ts"],
-  "timeout": 0
+  "timeout": 0,
+  "parallel": true,
+  "node-option": ["no-experimental-strip-types"]
 }

--- a/dev-packages/cli/.mocharc.json
+++ b/dev-packages/cli/.mocharc.json
@@ -2,5 +2,6 @@
   "$schema": "https://json.schemastore.org/mocharc",
   "extends": "@eclipse-glsp/mocha-config",
   "spec": ["./src/**/*.spec.ts"],
-  "timeout": 30000
+  "timeout": 30000,
+  "node-option": ["no-experimental-strip-types"]
 }

--- a/dev-packages/cli/.nycrc
+++ b/dev-packages/cli/.nycrc
@@ -1,0 +1,3 @@
+{
+    "extends": "@eclipse-glsp/nyc-config"
+}

--- a/dev-packages/cli/README.md
+++ b/dev-packages/cli/README.md
@@ -26,6 +26,7 @@ Commands:
   updateNext|u [options] [rootDir]      Updates all `next` dependencies in GLSP project to the latest version
   generateIndex [options] <rootDir...>  Generate index files in a given source directory.
   releng                                Commands for GLSP release engineering (Linux only, intended for CI/Maintainer use).
+  repo                                  Multi-repository management for GLSP projects
   help [command]                        display help for command
 ```
 
@@ -198,11 +199,272 @@ Options:
   -h, --help               display help for command
 ```
 
+## repo
+
+Multi-repository workspace management for GLSP development.
+All repositories are expected to live as siblings in a shared workspace directory (e.g. `~/glsp/glsp-client`, `~/glsp/glsp-server-node`, etc.).
+Repositories are auto-discovered by scanning the workspace directory for known GLSP repo names.
+The workspace directory is resolved automatically by walking up from the current directory; it can be overridden with `--dir`.
+The clone protocol is auto-detected: if the GitHub CLI (`gh`) is installed and authenticated, `gh` is used; otherwise `https`.
+This can be overridden per command via `--protocol`.
+
+```bash
+$ glsp repo -h
+Usage: glsp repo [options] [command]
+
+Multi-repository management for GLSP projects
+
+Options:
+  -h, --help                        display help for command
+
+Commands:
+  clone [options] [repos...]        Clone GLSP repositories
+  fork [options] <user>             Add fork remotes to already-cloned repositories
+  build [options]                   Build repositories (dependency-ordered)
+  link [options]                    Interlink repositories via yarn link
+  unlink [options]                  Remove yarn links between repositories
+  pwd [options]                     Print resolved paths for all discovered repositories
+  log [options]                     Print the last commit for all discovered repositories
+  workspace                         Manage VS Code workspace files for GLSP projects
+  glsp                              Operations on the glsp repository
+  glsp-server-node|server-node      Operations on the glsp-server-node repository
+  glsp-client|client                Operations on the glsp-client repository
+  glsp-theia-integration|theia      Operations on the glsp-theia-integration repository
+  glsp-vscode-integration|vscode    Operations on the glsp-vscode-integration repository
+  glsp-eclipse-integration|eclipse  Operations on the glsp-eclipse-integration repository
+  glsp-server|server-java           Operations on the glsp-server repository
+  glsp-playwright|playwright        Operations on the glsp-playwright repository
+  help [command]                    display help for command
+```
+
+### clone
+
+Clones GLSP repositories into the workspace directory.
+Repositories can be specified as positional arguments, via `--preset`, or interactively with `--interactive`.
+
+```console
+$ glsp repo clone -h
+Usage: glsp repo clone [options] [repos...]
+
+Clone GLSP repositories
+
+Arguments:
+  repos                      Repositories to clone (can combine with --preset)
+
+Options:
+  -d, --dir <path>           Target directory for repo clones
+  -p, --protocol <protocol>  Git clone protocol (default: gh|https) (choices: "ssh", "https", "gh")
+  -b, --branch <name>        Branch or tag to check out after cloning
+  --fork <user>              Clone from a fork and set up dual-remote (origin=fork, upstream=eclipse-glsp)
+  --override <mode>          How to handle an existing target directory (choices: "rename", "remove")
+  --preset <name>            Clone repos from a preset (choices: "core", "theia", "vscode",
+                             "eclipse", "playwright", "all")
+  -i, --interactive          Guided setup: choose preset, protocol, and fork interactively (default: false)
+  --no-fail-fast             Continue cloning after a failure
+  -v, --verbose              Verbose output (default: false)
+  -h, --help                 display help for command
+```
+
+### fork
+
+Adds fork remotes to already-cloned repositories. For each repo, restructures the git remotes so that
+`origin` points to your fork and `upstream` points to `eclipse-glsp`. If the fork doesn't exist on GitHub
+and the `gh` CLI is available, it will create one.
+
+```console
+$ glsp repo fork -h
+Usage: glsp repo fork [options] <user>
+
+Add fork remotes to already-cloned repositories
+
+Arguments:
+  user                       GitHub username for the fork
+
+Options:
+  -d, --dir <path>           Target directory where repos are cloned
+  -p, --protocol <protocol>  Git clone protocol (default: gh|https) (choices: "ssh", "https", "gh")
+  -r, --repo <name...>       Fork only these repos
+  --preset <name>            Fork repos from a preset (choices: "core", "theia", "vscode",
+                             "eclipse", "playwright", "all")
+  -v, --verbose              Verbose output (default: false)
+  -h, --help                 display help for command
+```
+
+### build
+
+Builds repositories in dependency order. Understands the GLSP dependency graph and builds prerequisites first.
+
+```console
+$ glsp repo build -h
+Usage: glsp repo build [options]
+
+Build repositories (dependency-ordered)
+
+Options:
+  -d, --dir <path>      Target directory where repos are cloned
+  -r, --repo <name...>  Build only these repos
+  --preset <name>       Build repos from a preset (choices: "core", "theia", "vscode",
+                        "eclipse", "playwright", "all")
+  --electron            Build Theia electron variant instead of browser (default: false)
+  --no-java             Skip repositories that require Java/Maven
+  --no-fail-fast        Continue building after a failure
+  -v, --verbose         Verbose output (default: false)
+  -h, --help            display help for command
+```
+
+### link / unlink
+
+Links (or unlinks) repositories via `yarn link` for cross-repo development.
+Repositories are processed in dependency order, and singleton dependencies (sprotty, inversify, etc.)
+are shared from `glsp-client` to avoid duplicate instances.
+
+```console
+$ glsp repo link -h
+Usage: glsp repo link [options]
+
+Interlink repositories via yarn link
+
+Options:
+  -d, --dir <path>      Target directory where repos are cloned
+  -r, --repo <name...>  Link only these repos
+  --preset <name>       Link repos from a preset (choices: "core", "theia", "vscode",
+                        "eclipse", "playwright", "all")
+  --no-fail-fast        Continue after a failure
+  -v, --verbose         Verbose output (default: false)
+  -h, --help            display help for command
+```
+
+### pwd
+
+```console
+$ glsp repo pwd -h
+Usage: glsp repo pwd [options]
+
+Print resolved paths for all discovered repositories
+
+Options:
+  -d, --dir <path>  Target directory where repos are cloned
+  --raw             Print repo<tab>path per line, no color (default: false)
+  -v, --verbose     Verbose output (default: false)
+  -h, --help        display help for command
+```
+
+### log
+
+```console
+$ glsp repo log -h
+Usage: glsp repo log [options]
+
+Print the last commit for all discovered repositories
+
+Options:
+  -d, --dir <path>      Target directory where repos are cloned
+  -r, --repo <name...>  Log only these repos
+  --preset <name>       Log repos from a preset (choices: "core", "theia", "vscode",
+                        "eclipse", "playwright", "all")
+  -v, --verbose         Verbose output (default: false)
+  -h, --help            display help for command
+```
+
+### workspace
+
+Manage VS Code multi-root workspace files.
+
+```console
+$ glsp repo workspace init -h
+Usage: glsp repo workspace init [options]
+
+Generate a VS Code multi-root workspace file
+
+Options:
+  -d, --dir <path>      Target directory where repos are cloned
+  -o, --output <path>   Output path for the workspace file
+  -r, --repo <name...>  Include only these repos
+  --preset <name>       Include repos from a preset (choices: "core", "theia", "vscode",
+                        "eclipse", "playwright", "all")
+  -v, --verbose         Verbose output (default: false)
+  -h, --help            display help for command
+```
+
+```console
+$ glsp repo workspace open -h
+Usage: glsp repo workspace open [options]
+
+Open the VS Code workspace file
+
+Options:
+  -d, --dir <path>  Target directory where repos are cloned
+  -v, --verbose     Verbose output (default: false)
+  -h, --help        display help for command
+```
+
+### Scoped repository commands
+
+Each repository has a set of scoped subcommands accessible via `glsp repo <name>` or its short alias.
+Short aliases: `client`, `server-node`, `theia`, `vscode`, `eclipse`, `server-java`, `playwright`.
+
+All repos support `clone`, `switch`, `build`, `pwd`, and `log` subcommands.
+Some repos have additional repo-specific commands:
+
+| Repo                      | Extra commands         |
+| ------------------------- | ---------------------- |
+| `glsp-client`             | `start`                |
+| `glsp-server-node`        | `start`                |
+| `glsp-server`             | `start`                |
+| `glsp-theia-integration`  | `start`, `open`        |
+| `glsp-vscode-integration` | `vsix-path`, `package` |
+
+```console
+$ glsp repo client -h
+Usage: glsp repo glsp-client|client [options] [command]
+
+Operations on the glsp-client repository
+
+Commands:
+  clone [options]   Clone the glsp-client repository
+  switch [options]  Switch branch or checkout a PR in glsp-client
+  build [options]   Build the glsp-client repository
+  pwd [options]     Print the resolved path for glsp-client
+  log [options]     Print the last commit for glsp-client
+  start [options]   Start the standalone example for glsp-client
+  help [command]    display help for command
+```
+
+```console
+$ glsp repo vscode -h
+Usage: glsp repo glsp-vscode-integration|vscode [options] [command]
+
+Operations on the glsp-vscode-integration repository
+
+Commands:
+  clone [options]      Clone the glsp-vscode-integration repository
+  switch [options]     Switch branch or checkout a PR in glsp-vscode-integration
+  build [options]      Build the glsp-vscode-integration repository
+  pwd [options]        Print the resolved path for glsp-vscode-integration
+  log [options]        Print the last commit for glsp-vscode-integration
+  vsix-path [options]  Print the path to the workflow VSIX file
+  package [options]    Package the workflow VS Code extension as a VSIX
+  help [command]       display help for command
+```
+
+```console
+$ glsp repo theia -h
+Usage: glsp repo glsp-theia-integration|theia [options] [command]
+
+Operations on the glsp-theia-integration repository
+
+Commands:
+  clone [options]   Clone the glsp-theia-integration repository
+  switch [options]  Switch branch or checkout a PR in glsp-theia-integration
+  build [options]   Build the glsp-theia-integration repository
+  pwd [options]     Print the resolved path for glsp-theia-integration
+  log [options]     Print the last commit for glsp-theia-integration
+  start [options]   Start the Theia application for glsp-theia-integration
+  open [options]    Open the Theia application in the browser for glsp-theia-integration
+  help [command]    display help for command
+```
+
 ## More information
 
 For more information, please visit the [Eclipse GLSP Umbrella repository](https://github.com/eclipse-glsp/glsp) and the [Eclipse GLSP Website](https://www.eclipse.org/glsp/).
 If you have questions, please raise them in the [discussions](https://github.com/eclipse-glsp/glsp/discussions) and have a look at our [communication and support options](https://www.eclipse.org/glsp/contact/).
-
-```
-
-```

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -45,12 +45,11 @@
   },
   "devDependencies": {
     "@eclipse-glsp/config": "2.7.0-next",
-    "@types/glob": "^8.1.0",
     "@types/semver": "^7.7.1",
     "commander": "^14.0.0",
     "esbuild": "~0.25.9",
-    "glob": "^10.4.5",
     "globby": "^14.1.0",
+    "open": "^10.0.0",
     "semver": "^7.7.2"
   },
   "publishConfig": {

--- a/dev-packages/cli/src/cli.spec.ts
+++ b/dev-packages/cli/src/cli.spec.ts
@@ -1,0 +1,481 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { Command } from 'commander';
+import { CheckHeaderCommand } from './commands/check-header';
+import { CoverageReportCommand } from './commands/coverage-report';
+import { GenerateIndex } from './commands/generate-index';
+import { RelengCommand } from './commands/releng/releng';
+import { RepoCommand } from './commands/repo/repo';
+import { UpdateNextCommand } from './commands/update-next';
+import { GLSPRepo } from './util';
+import { createSubrepoCommand } from './commands/repo/subrepos';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const optionLongs = (cmd: Command): string[] => cmd.options.map(o => o.long!);
+const subcommandNames = (cmd: Command): string[] => cmd.commands.map(c => c.name());
+const findSub = (parent: Command, name: string): Command => {
+    const sub = parent.commands.find(c => c.name() === name);
+    expect(sub, `subcommand '${name}' not found on '${parent.name()}'`).to.exist;
+    return sub!;
+};
+const choices = (cmd: Command, long: string): string[] | undefined => {
+    const opt = cmd.options.find(o => o.long === long);
+    expect(opt, `option '${long}' not found on '${cmd.name()}'`).to.exist;
+    return opt!.argChoices;
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('cli', () => {
+    // ── Top-level ──────────────────────────────────────────────────────
+
+    describe('top-level commands', () => {
+        describe('coverageReport', () => {
+            it('should have expected options', () => {
+                expect(optionLongs(CoverageReportCommand)).to.include.members(['--projectRoot', '--coverageScript']);
+            });
+        });
+
+        describe('checkHeaders', () => {
+            it('should accept a <rootDir> argument', () => {
+                expect(CheckHeaderCommand.registeredArguments).to.have.lengthOf(1);
+                expect(CheckHeaderCommand.registeredArguments[0].name()).to.equal('rootDir');
+                expect(CheckHeaderCommand.registeredArguments[0].required).to.be.true;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(CheckHeaderCommand)).to.include.members([
+                    '--type',
+                    '--fileExtensions',
+                    '--exclude',
+                    '--no-exclude-defaults',
+                    '--json',
+                    '--autoFix',
+                    '--commit'
+                ]);
+            });
+
+            it('should restrict --type choices', () => {
+                expect(choices(CheckHeaderCommand, '--type')).to.deep.equal(['full', 'changes', 'lastCommit']);
+            });
+        });
+
+        describe('updateNext', () => {
+            it('should have alias "u"', () => {
+                expect(UpdateNextCommand.alias()).to.equal('u');
+            });
+
+            it('should accept an optional [rootDir] argument', () => {
+                expect(UpdateNextCommand.registeredArguments).to.have.lengthOf(1);
+                expect(UpdateNextCommand.registeredArguments[0].required).to.be.false;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(UpdateNextCommand)).to.include.members(['--verbose']);
+            });
+        });
+
+        describe('generateIndex', () => {
+            it('should accept a variadic <rootDir...> argument', () => {
+                expect(GenerateIndex.registeredArguments).to.have.lengthOf(1);
+                expect(GenerateIndex.registeredArguments[0].variadic).to.be.true;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(GenerateIndex)).to.include.members([
+                    '--singleIndex',
+                    '--forceOverwrite',
+                    '--match',
+                    '--ignore',
+                    '--style',
+                    '--ignoreFile',
+                    '--verbose'
+                ]);
+            });
+
+            it('should restrict --style choices', () => {
+                expect(choices(GenerateIndex, '--style')).to.deep.equal(['commonjs', 'esm']);
+            });
+        });
+    });
+
+    // ── Releng ─────────────────────────────────────────────────────────
+
+    describe('releng', () => {
+        it('should have version and prepare subcommands', () => {
+            expect(subcommandNames(RelengCommand)).to.include.members(['version', 'prepare']);
+        });
+
+        describe('version', () => {
+            const cmd = findSub(RelengCommand, 'version');
+
+            it('should accept <versionType> argument with choices', () => {
+                const arg = cmd.registeredArguments[0];
+                expect(arg.name()).to.equal('versionType');
+                expect(arg.required).to.be.true;
+                expect(arg.argChoices).to.deep.equal(['major', 'minor', 'patch', 'custom', 'next']);
+            });
+
+            it('should accept optional [customVersion] argument', () => {
+                expect(cmd.registeredArguments[1].name()).to.equal('customVersion');
+                expect(cmd.registeredArguments[1].required).to.be.false;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--verbose', '--repoDir']);
+            });
+        });
+
+        describe('prepare', () => {
+            const cmd = findSub(RelengCommand, 'prepare');
+
+            it('should accept <versionType> argument with choices', () => {
+                const arg = cmd.registeredArguments[0];
+                expect(arg.argChoices).to.deep.equal(['major', 'minor', 'patch', 'custom', 'next']);
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--verbose', '--repoDir', '--no-push', '--draft', '--no-check']);
+            });
+        });
+    });
+
+    // ── Repo ───────────────────────────────────────────────────────────
+
+    describe('repo', () => {
+        it('should register all top-level repo subcommands', () => {
+            expect(subcommandNames(RepoCommand)).to.include.members([
+                'clone',
+                'fork',
+                'build',
+                'link',
+                'unlink',
+                'pwd',
+                'log',
+                'workspace'
+            ]);
+        });
+
+        it('should register a subrepo command for each GLSPRepo', () => {
+            for (const repoName of GLSPRepo.choices) {
+                expect(subcommandNames(RepoCommand), `subrepo '${repoName}' should be registered`).to.include(repoName);
+            }
+        });
+
+        describe('clone', () => {
+            const cmd = findSub(RepoCommand, 'clone');
+
+            it('should accept optional [repos...] argument', () => {
+                expect(cmd.registeredArguments[0].variadic).to.be.true;
+                expect(cmd.registeredArguments[0].required).to.be.false;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members([
+                    '--dir',
+                    '--protocol',
+                    '--branch',
+                    '--fork',
+                    '--override',
+                    '--preset',
+                    '--interactive',
+                    '--no-fail-fast',
+                    '--verbose'
+                ]);
+            });
+
+            it('should restrict --protocol choices', () => {
+                expect(choices(cmd, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+            });
+
+            it('should restrict --override choices', () => {
+                expect(choices(cmd, '--override')).to.deep.equal(['rename', 'remove']);
+            });
+
+            it('should restrict --preset choices', () => {
+                expect(choices(cmd, '--preset')).to.include.members(['core', 'theia', 'vscode', 'eclipse', 'playwright', 'all']);
+            });
+        });
+
+        describe('fork', () => {
+            const cmd = findSub(RepoCommand, 'fork');
+
+            it('should accept required <user> argument', () => {
+                expect(cmd.registeredArguments[0].name()).to.equal('user');
+                expect(cmd.registeredArguments[0].required).to.be.true;
+            });
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--dir', '--protocol', '--repo', '--preset', '--verbose']);
+            });
+
+            it('should restrict --protocol choices', () => {
+                expect(choices(cmd, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+            });
+        });
+
+        describe('build', () => {
+            const cmd = findSub(RepoCommand, 'build');
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members([
+                    '--dir',
+                    '--repo',
+                    '--preset',
+                    '--electron',
+                    '--no-java',
+                    '--no-fail-fast',
+                    '--verbose'
+                ]);
+            });
+        });
+
+        describe('link', () => {
+            const cmd = findSub(RepoCommand, 'link');
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']);
+            });
+        });
+
+        describe('unlink', () => {
+            const cmd = findSub(RepoCommand, 'unlink');
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']);
+            });
+        });
+
+        describe('pwd', () => {
+            const cmd = findSub(RepoCommand, 'pwd');
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--dir', '--raw', '--verbose']);
+            });
+        });
+
+        describe('log', () => {
+            const cmd = findSub(RepoCommand, 'log');
+
+            it('should have expected options', () => {
+                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--verbose']);
+            });
+        });
+
+        describe('workspace', () => {
+            const workspace = findSub(RepoCommand, 'workspace');
+
+            it('should have init and open subcommands', () => {
+                expect(subcommandNames(workspace)).to.include.members(['init', 'open']);
+            });
+
+            describe('init', () => {
+                const cmd = findSub(workspace, 'init');
+
+                it('should have expected options', () => {
+                    expect(optionLongs(cmd)).to.include.members(['--dir', '--output', '--repo', '--preset', '--verbose']);
+                });
+            });
+
+            describe('open', () => {
+                const cmd = findSub(workspace, 'open');
+
+                it('should have expected options', () => {
+                    expect(optionLongs(cmd)).to.include.members(['--dir', '--verbose']);
+                });
+            });
+        });
+
+        // ── Subrepo commands ───────────────────────────────────────────
+
+        describe('subrepo commands', () => {
+            const SHORT_ALIASES: Partial<Record<string, string>> = {
+                'glsp-client': 'client',
+                'glsp-server-node': 'server-node',
+                'glsp-theia-integration': 'theia',
+                'glsp-vscode-integration': 'vscode',
+                'glsp-eclipse-integration': 'eclipse',
+                'glsp-server': 'server-java',
+                'glsp-playwright': 'playwright'
+            };
+
+            for (const repoName of GLSPRepo.choices) {
+                describe(repoName, () => {
+                    const cmd = createSubrepoCommand(repoName);
+
+                    it('should have common subcommands', () => {
+                        expect(subcommandNames(cmd)).to.include.members(['clone', 'switch', 'build', 'pwd', 'log']);
+                    });
+
+                    if (SHORT_ALIASES[repoName]) {
+                        it(`should have alias "${SHORT_ALIASES[repoName]}"`, () => {
+                            expect(cmd.alias()).to.equal(SHORT_ALIASES[repoName]);
+                        });
+                    }
+
+                    describe('scoped clone', () => {
+                        const clone = findSub(cmd, 'clone');
+
+                        it('should have expected options', () => {
+                            expect(optionLongs(clone)).to.include.members([
+                                '--dir',
+                                '--protocol',
+                                '--branch',
+                                '--fork',
+                                '--override',
+                                '--verbose'
+                            ]);
+                        });
+
+                        it('should restrict --protocol choices', () => {
+                            expect(choices(clone, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+                        });
+
+                        it('should restrict --override choices', () => {
+                            expect(choices(clone, '--override')).to.deep.equal(['rename', 'remove']);
+                        });
+                    });
+
+                    describe('scoped switch', () => {
+                        const sw = findSub(cmd, 'switch');
+
+                        it('should have expected options', () => {
+                            expect(optionLongs(sw)).to.include.members(['--branch', '--dir', '--pr', '--force', '--verbose']);
+                        });
+                    });
+
+                    describe('scoped build', () => {
+                        const build = findSub(cmd, 'build');
+
+                        it('should have expected options', () => {
+                            expect(optionLongs(build)).to.include.members(['--dir', '--verbose']);
+                        });
+
+                        if (repoName === 'glsp-theia-integration') {
+                            it('should have --electron option', () => {
+                                expect(optionLongs(build)).to.include('--electron');
+                            });
+                        }
+                    });
+
+                    describe('scoped pwd', () => {
+                        const pwd = findSub(cmd, 'pwd');
+
+                        it('should have expected options', () => {
+                            expect(optionLongs(pwd)).to.include.members(['--dir', '--verbose']);
+                        });
+                    });
+
+                    describe('scoped log', () => {
+                        const log = findSub(cmd, 'log');
+
+                        it('should have expected options', () => {
+                            expect(optionLongs(log)).to.include.members(['--dir', '--verbose']);
+                        });
+                    });
+                });
+            }
+
+            // ── Repo-specific extra commands ───────────────────────────
+
+            describe('glsp-client extras', () => {
+                const cmd = createSubrepoCommand('glsp-client');
+                const start = findSub(cmd, 'start');
+
+                it('should have start command', () => {
+                    expect(subcommandNames(cmd)).to.include('start');
+                });
+
+                it('should have expected start options', () => {
+                    expect(optionLongs(start)).to.include.members(['--dir', '--browser', '--verbose']);
+                });
+            });
+
+            describe('glsp-server-node extras', () => {
+                const cmd = createSubrepoCommand('glsp-server-node');
+                const start = findSub(cmd, 'start');
+
+                it('should have start command', () => {
+                    expect(subcommandNames(cmd)).to.include('start');
+                });
+
+                it('should have expected start options', () => {
+                    expect(optionLongs(start)).to.include.members(['--dir', '--socket', '--verbose']);
+                });
+            });
+
+            describe('glsp-server extras', () => {
+                const cmd = createSubrepoCommand('glsp-server');
+                const start = findSub(cmd, 'start');
+
+                it('should have start command', () => {
+                    expect(subcommandNames(cmd)).to.include('start');
+                });
+
+                it('should have expected start options', () => {
+                    expect(optionLongs(start)).to.include.members(['--dir', '--socket', '--verbose']);
+                });
+            });
+
+            describe('glsp-theia-integration extras', () => {
+                const cmd = createSubrepoCommand('glsp-theia-integration');
+
+                it('should have start command', () => {
+                    expect(subcommandNames(cmd)).to.include('start');
+                });
+
+                it('should have expected start options', () => {
+                    const start = findSub(cmd, 'start');
+                    expect(optionLongs(start)).to.include.members(['--dir', '--electron', '--debug', '--verbose']);
+                });
+
+                it('should have open command', () => {
+                    expect(subcommandNames(cmd)).to.include('open');
+                });
+
+                it('should have expected open options', () => {
+                    const open = findSub(cmd, 'open');
+                    expect(optionLongs(open)).to.include.members(['--verbose']);
+                });
+            });
+
+            describe('glsp-vscode-integration extras', () => {
+                const cmd = createSubrepoCommand('glsp-vscode-integration');
+
+                it('should have vsix-path command', () => {
+                    expect(subcommandNames(cmd)).to.include('vsix-path');
+                });
+
+                it('should have expected vsix-path options', () => {
+                    const vsixPath = findSub(cmd, 'vsix-path');
+                    expect(optionLongs(vsixPath)).to.include.members(['--dir', '--verbose']);
+                });
+
+                it('should have package command', () => {
+                    expect(subcommandNames(cmd)).to.include('package');
+                });
+
+                it('should have expected package options', () => {
+                    const pkg = findSub(cmd, 'package');
+                    expect(optionLongs(pkg)).to.include.members(['--dir', '--verbose']);
+                });
+            });
+        });
+    });
+});

--- a/dev-packages/cli/src/cli.ts
+++ b/dev-packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2025 EclipseSource and others.
+ * Copyright (c) 2022-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,8 +17,9 @@ import { CheckHeaderCommand } from './commands/check-header';
 import { CoverageReportCommand } from './commands/coverage-report';
 import { GenerateIndex } from './commands/generate-index';
 import { RelengCommand } from './commands/releng/releng';
+import { RepoCommand } from './commands/repo/repo';
 import { UpdateNextCommand } from './commands/update-next';
-import { COMMAND_VERSION, LOGGER, baseCommand } from './util';
+import { COMMAND_VERSION, LOGGER, baseCommand, initGlobby } from './util';
 
 const app = baseCommand() //
     .version(COMMAND_VERSION)
@@ -27,9 +28,12 @@ const app = baseCommand() //
     .addCommand(CheckHeaderCommand)
     .addCommand(UpdateNextCommand)
     .addCommand(GenerateIndex)
-    .addCommand(RelengCommand);
+    .addCommand(RelengCommand)
+    .addCommand(RepoCommand);
 
-app.parseAsync(process.argv).catch(err => {
-    LOGGER.error(err);
-    process.exit(1);
-});
+initGlobby()
+    .then(() => app.parseAsync(process.argv))
+    .catch(err => {
+        LOGGER.error(err);
+        process.exit(1);
+    });

--- a/dev-packages/cli/src/commands/check-header.ts
+++ b/dev-packages/cli/src/commands/check-header.ts
@@ -27,6 +27,7 @@ import {
     getChangesOfLastCommit,
     getLastModificationDate,
     getUncommittedChanges,
+    globby,
     readFile,
     replaceInFile,
     resolveFiles,
@@ -102,8 +103,7 @@ async function getFiles(rootDir: string, options: HeaderCheckOptions): Promise<s
     const excludePattern = options.exclude;
 
     if (options.type === 'full') {
-        const { globbySync } = await import('globby');
-        const result = globbySync(includePattern, {
+        const result = globby(includePattern, {
             cwd: rootDir,
             ignore: excludePattern,
             gitignore: true

--- a/dev-packages/cli/src/commands/generate-index.ts
+++ b/dev-packages/cli/src/commands/generate-index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023-2025 EclipseSource and others.
+ * Copyright (c) 2023-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,7 +18,7 @@ import { createOption } from 'commander';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { LOGGER, baseCommand, cd, configureLogger, validateDirectory } from '../util';
+import { GlobOptions, LOGGER, baseCommand, cd, configureLogger, globby, validateDirectory } from '../util';
 export interface GenerateIndexCmdOptions {
     singleIndex: boolean;
     forceOverwrite: boolean;
@@ -27,15 +27,6 @@ export interface GenerateIndexCmdOptions {
     ignoreFile: string;
     style: 'commonjs' | 'esm';
     verbose: boolean;
-}
-
-// Partial type of the globby imports since we can not use the esm type directly
-interface GlobbyOptions {
-    ignore: string[];
-    cwd: string;
-    onlyFiles: boolean;
-    markDirectories: true;
-    ignoreFiles: string;
 }
 
 export const GenerateIndex = baseCommand() //
@@ -54,31 +45,24 @@ export const GenerateIndex = baseCommand() //
 export async function generateIndices(rootDirs: string[], options: GenerateIndexCmdOptions): Promise<void> {
     configureLogger(options.verbose);
     const dirs = rootDirs.map(rootDir => validateDirectory(path.resolve(rootDir)));
-    const globby = await import('globby');
-    const ignoreFilter: (pattern: string[], options: GlobbyOptions) => string[] = (pattern, globbyOptions) =>
-        globby.globbySync(pattern, globbyOptions);
-    dirs.forEach(dir => generateIndex(dir, ignoreFilter, options));
+    dirs.forEach(dir => generateIndex(dir, options));
 }
 
-export async function generateIndex(
-    rootDir: string,
-    ignoreFilter: (pattern: string[], options: GlobbyOptions) => string[],
-    options: GenerateIndexCmdOptions
-): Promise<void> {
+export function generateIndex(rootDir: string, options: GenerateIndexCmdOptions): void {
     LOGGER.debug('Run generateIndex for', rootDir, 'with the following options:', options);
     const cwd = cd(rootDir);
     // we want to match all given patterns and subdirectories and ignore all given patterns and (generated) index files
     const pattern = typeof options.match === 'boolean' ? ['**/'] : [...options.match, '**/'];
     const ignore = typeof options.ignore === 'boolean' ? ['**/index.ts'] : [...options.ignore, '**/index.ts'];
-    const globbyOptions: GlobbyOptions = {
+    const globOptions: GlobOptions = {
         ignore,
         cwd,
         onlyFiles: options.singleIndex,
-        markDirectories: true, // directories have '/' at the end
-        ignoreFiles: '**/' + options.ignoreFile // users can add this file in their directories to ignore files for indexing
+        markDirectories: true,
+        ignoreFiles: '**/' + options.ignoreFile
     };
-    LOGGER.debug('Search for children using the following globby options', globbyOptions);
-    const files = ignoreFilter(pattern, globbyOptions);
+    LOGGER.debug('Search for children using the following glob options', globOptions);
+    const files = globby(pattern, globOptions);
     LOGGER.debug('All children considered in the input directory', files);
 
     const relativeRootDirectory = '';

--- a/dev-packages/cli/src/commands/releng/common.spec.ts
+++ b/dev-packages/cli/src/commands/releng/common.spec.ts
@@ -16,11 +16,25 @@
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import * as fileUtil from '../../util/file-util';
 import { LOGGER } from '../../util/logger';
 import { PackageHelper } from '../../util/package-util';
+import * as packageUtil from '../../util/package-util';
 import * as processUtil from '../../util/process-util';
 import * as gitUtil from '../../util/git-util';
-import { getGLSPDependencies, GLSPRepo, isGithubCLIAuthenticated } from './common';
+import {
+    VersionType,
+    asMvnVersion,
+    getChangeLogChanges,
+    getGLSPDependencies,
+    getLastReleaseTag,
+    getLocalVersion,
+    getVersionFromPackage,
+    getVersionFromPom,
+    GLSPRepo,
+    isGithubCLIAuthenticated,
+    isNextVersion
+} from './common';
 
 describe('common', () => {
     let sandbox: sinon.SinonSandbox;
@@ -70,9 +84,10 @@ describe('common', () => {
             expect(result).to.be.false;
         });
 
-        it('should propagate error when gh is not installed', () => {
-            sandbox.stub(processUtil, 'exec').throws(new Error('Github CLI is not installed!'));
-            expect(() => isGithubCLIAuthenticated()).to.throw(/not installed/);
+        it('should return false when gh is not installed', () => {
+            sandbox.stub(processUtil, 'exec').throws(new Error('gh not found'));
+            const result = isGithubCLIAuthenticated();
+            expect(result).to.be.false;
         });
     });
 
@@ -107,6 +122,203 @@ describe('common', () => {
 
             const result = getGLSPDependencies(pkg);
             expect(result).to.deep.equal([]);
+        });
+    });
+
+    describe('isNextVersion', () => {
+        it('should return true for -next suffix', () => {
+            expect(isNextVersion('1.0.0-next')).to.be.true;
+        });
+
+        it('should return true for .SNAPSHOT suffix', () => {
+            expect(isNextVersion('1.0.0.SNAPSHOT')).to.be.true;
+        });
+
+        it('should return false for a release version', () => {
+            expect(isNextVersion('1.0.0')).to.be.false;
+        });
+    });
+
+    describe('asMvnVersion', () => {
+        it('should convert -next to -SNAPSHOT', () => {
+            expect(asMvnVersion('1.0.0-next')).to.equal('1.0.0-SNAPSHOT');
+        });
+
+        it('should return release versions unchanged', () => {
+            expect(asMvnVersion('2.3.1')).to.equal('2.3.1');
+        });
+    });
+
+    describe('VersionType.validate', () => {
+        it('should throw when type is custom but no version is provided', () => {
+            expect(() => VersionType.validate('custom')).to.throw(/Custom version must be provided/);
+        });
+
+        it('should accept custom type with a version', () => {
+            expect(() => VersionType.validate('custom', '1.0.0')).to.not.throw();
+        });
+
+        it('should warn when a custom version is provided for non-custom type', () => {
+            const warnStub = sandbox.stub(console, 'warn');
+            VersionType.validate('minor', '1.0.0');
+            expect(warnStub.calledOnce).to.be.true;
+        });
+
+        it('should accept non-custom type without a version', () => {
+            expect(() => VersionType.validate('minor')).to.not.throw();
+        });
+    });
+
+    describe('VersionType.deriveVersion', () => {
+        it('should return the custom version for npm repos', () => {
+            const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
+            const result = VersionType.deriveVersion(options, '99.0.0');
+            expect(result).to.equal('99.0.0');
+        });
+
+        it('should throw for invalid custom version on npm repos', () => {
+            const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
+            expect(() => VersionType.deriveVersion(options, 'not-semver')).to.throw(/Not a valid custom version/);
+        });
+
+        it('should accept any custom version for java repos', () => {
+            const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-server' as const, verbose: false };
+            const result = VersionType.deriveVersion(options, '2.0.0.qualifier');
+            expect(result).to.equal('2.0.0.qualifier');
+        });
+
+        it('should derive minor version from local package', () => {
+            sandbox.stub(packageUtil, 'readPackage').returns({ content: { version: '1.2.0' } } as unknown as PackageHelper);
+            const options = { versionType: 'minor' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
+            const result = VersionType.deriveVersion(options);
+            expect(result).to.equal('1.3.0');
+        });
+
+        it('should derive next version with -next suffix', () => {
+            sandbox.stub(packageUtil, 'readPackage').returns({ content: { version: '1.2.0' } } as unknown as PackageHelper);
+            const options = { versionType: 'next' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
+            const result = VersionType.deriveVersion(options);
+            expect(result).to.equal('1.3.0-next');
+        });
+    });
+
+    describe('getLocalVersion', () => {
+        it('should read from pom.xml for glsp-server', () => {
+            sandbox.stub(fileUtil, 'readFile').returns('<version>2.0.0</version>');
+            expect(getLocalVersion('/repo', 'glsp-server')).to.equal('2.0.0');
+        });
+
+        it('should read from server/pom.xml for glsp-eclipse-integration', () => {
+            const readStub = sandbox.stub(fileUtil, 'readFile').returns('<version>2.1.0</version>');
+            expect(getLocalVersion('/repo', 'glsp-eclipse-integration')).to.equal('2.1.0');
+            expect(readStub.firstCall.args[0]).to.contain('server');
+        });
+
+        it('should read from package.json for npm repos', () => {
+            sandbox.stub(packageUtil, 'readPackage').returns({ content: { version: '1.5.0' } } as unknown as PackageHelper);
+            expect(getLocalVersion('/repo', 'glsp-client')).to.equal('1.5.0');
+        });
+    });
+
+    describe('getVersionFromPom', () => {
+        it('should extract version from pom.xml', () => {
+            sandbox.stub(fileUtil, 'readFile').returns(
+                `<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <version>2.7.0-SNAPSHOT</version>
+</project>`
+            );
+            expect(getVersionFromPom('/repo')).to.equal('2.7.0-SNAPSHOT');
+        });
+
+        it('should throw when no version is found', () => {
+            sandbox.stub(fileUtil, 'readFile').returns('<project></project>');
+            expect(() => getVersionFromPom('/repo')).to.throw(/Could not find version/);
+        });
+    });
+
+    describe('getVersionFromPackage', () => {
+        it('should return the version from package.json', () => {
+            sandbox.stub(packageUtil, 'readPackage').returns({ content: { version: '1.0.0' } } as unknown as PackageHelper);
+            expect(getVersionFromPackage('/repo')).to.equal('1.0.0');
+        });
+
+        it('should throw when no version is found', () => {
+            sandbox.stub(packageUtil, 'readPackage').returns({ content: {} } as unknown as PackageHelper);
+            expect(() => getVersionFromPackage('/repo')).to.throw(/No version found/);
+        });
+    });
+
+    describe('getLastReleaseTag', () => {
+        it('should return the first valid semver tag starting with v', () => {
+            sandbox.stub(processUtil, 'exec').returns('v2.0.0\nv1.0.0\nsome-tag');
+            expect(getLastReleaseTag('/repo')).to.equal('v2.0.0');
+        });
+
+        it('should skip pre-release tags', () => {
+            sandbox.stub(processUtil, 'exec').returns('v2.0.0-rc.1\nv1.0.0');
+            expect(getLastReleaseTag('/repo')).to.equal('v1.0.0');
+        });
+
+        it('should skip tags without v prefix', () => {
+            sandbox.stub(processUtil, 'exec').returns('release-1.0\nv0.9.0');
+            expect(getLastReleaseTag('/repo')).to.equal('v0.9.0');
+        });
+
+        it('should return undefined when no valid tag exists', () => {
+            sandbox.stub(processUtil, 'exec').returns('nightly\nsome-tag');
+            expect(getLastReleaseTag('/repo')).to.be.undefined;
+        });
+    });
+
+    describe('getChangeLogChanges', () => {
+        const changelogContent = [
+            '# Changelog',
+            '',
+            '## [v2.0.0 - 2026-01-15]',
+            '',
+            '### Features',
+            '',
+            '- Added feature A',
+            '- Added feature B',
+            '',
+            '## [v1.0.0 - 2025-06-01]',
+            '',
+            '- Initial release'
+        ].join('\n');
+
+        it('should extract the changelog section for the given version', () => {
+            sandbox.stub(fileUtil, 'readFile').returns(changelogContent);
+            sandbox.stub(processUtil, 'exec').returns('v1.0.0');
+            const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
+            expect(result).to.contain('Added feature A');
+            expect(result).to.contain('Added feature B');
+            expect(result).to.not.contain('Initial release');
+        });
+
+        it('should append a full changelog link when a previous tag exists', () => {
+            sandbox.stub(fileUtil, 'readFile').returns(changelogContent);
+            sandbox.stub(processUtil, 'exec').returns('v1.0.0');
+            const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
+            expect(result).to.contain('Full Changelog');
+            expect(result).to.contain('v1.0.0...v2.0.0');
+        });
+
+        it('should throw when no section matches the version', () => {
+            sandbox.stub(fileUtil, 'readFile').returns(changelogContent);
+            sandbox.stub(processUtil, 'exec').returns('');
+            expect(() => getChangeLogChanges({ repoDir: '/repo', version: '9.9.9', repo: 'glsp-client' })).to.throw(
+                /No changelog section found/
+            );
+        });
+
+        it('should demote headings by one level', () => {
+            sandbox.stub(fileUtil, 'readFile').returns(changelogContent);
+            sandbox.stub(processUtil, 'exec').returns('');
+            const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
+            expect(result).to.contain('## Features');
+            expect(result).to.not.contain('### Features');
         });
     });
 });

--- a/dev-packages/cli/src/commands/releng/common.ts
+++ b/dev-packages/cli/src/commands/releng/common.ts
@@ -16,42 +16,17 @@
 
 import * as path from 'path';
 import * as semver from 'semver';
-import { LOGGER, PackageHelper, configureExec, configureLogger, exec, getRemoteUrl, readFile, readPackage } from '../../util';
-
-export type GLSPRepo = (typeof GLSPRepo.choices)[number];
-export namespace GLSPRepo {
-    export const choices = [
-        'glsp',
-        'glsp-server-node',
-        'glsp-client',
-        'glsp-theia-integration',
-        'glsp-vscode-integration',
-        'glsp-eclipse-integration',
-        'glsp-server',
-        'glsp-playwright'
-    ] as const;
-
-    export function is(object: unknown): object is GLSPRepo {
-        return typeof object === 'string' && choices.includes(object as GLSPRepo);
-    }
-
-    export function isNpmRepo(repo: string): boolean {
-        return repo !== 'glsp-server' && repo !== 'glsp-eclipse-integration';
-    }
-
-    export function deriveFromDirectory(repoDir: string): GLSPRepo | undefined {
-        const remoteUrl = getRemoteUrl(repoDir);
-        const repo = remoteUrl.substring(remoteUrl.lastIndexOf('/') + 1).replace('.git', '');
-        if (!repo) {
-            LOGGER.warn(`No git repository found in ${repoDir}`);
-            return undefined;
-        }
-        if (!is(repo)) {
-            return undefined;
-        }
-        return repo;
-    }
-}
+import {
+    GLSPRepo,
+    LOGGER,
+    checkGHCli,
+    configureEnv,
+    exec,
+    getGLSPDependencies,
+    isGithubCLIAuthenticated,
+    readFile,
+    readPackage
+} from '../../util';
 
 export interface RelengOptions {
     verbose: boolean;
@@ -62,32 +37,6 @@ export interface RelengOptions {
 }
 
 export type RelengCmdOptions = Omit<RelengOptions, 'version' | 'repo' | 'versionType'>;
-
-export function checkGHCli(): void {
-    LOGGER.debug('Verify that Github CLI is configured correctly');
-    if (!isGithubCLIAuthenticated()) {
-        throw new Error("Github CLI is not configured properly. No user is logged in for host 'github.com'");
-    }
-}
-
-export function isGithubCLIAuthenticated(): boolean {
-    LOGGER.debug('Verify that Github CLI is installed');
-    exec('which gh', { silent: true, errorMsg: 'Github CLI is not installed!' });
-
-    try {
-        exec('gh auth status');
-    } catch (error) {
-        LOGGER.warn('Github CLI authentication status could not be determined.');
-        return false;
-    }
-    LOGGER.debug('Github CLI is authenticated and ready to use');
-    return true;
-}
-
-export function configureEnv(options: RelengCmdOptions): void {
-    configureLogger(options.verbose);
-    configureExec({ silent: !options.verbose, verbose: options.verbose });
-}
 
 // Versioning
 
@@ -209,12 +158,6 @@ export async function checkIfNpmVersionIsNew(pckgName: string, newVersion: strin
     throw new Error(`Version '${newVersion} is already present on NPM!}`);
 }
 
-export function getGLSPDependencies(pkg: PackageHelper): string[] {
-    const deps = pkg.content.dependencies ? Object.keys(pkg.content.dependencies) : [];
-    const devDeps = pkg.content.devDependencies ? Object.keys(pkg.content.devDependencies) : [];
-    return [...deps, ...devDeps].filter(dep => dep.startsWith('@eclipse-glsp'));
-}
-
 /**
  * Returns the most recent release tag (excluding pre-releases and custom qualifier tags).
  * Only tags that start with 'v' followed by a semantic version (e.g. v1.0.0) are considered.
@@ -256,3 +199,5 @@ export function getChangeLogChanges(options: Pick<RelengOptions, 'repoDir' | 've
     }
     return content;
 }
+
+export { GLSPRepo, checkGHCli, configureEnv, getGLSPDependencies, isGithubCLIAuthenticated };

--- a/dev-packages/cli/src/commands/releng/prepare.ts
+++ b/dev-packages/cli/src/commands/releng/prepare.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 EclipseSource and others.
+ * Copyright (c) 2025-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/dev-packages/cli/src/commands/releng/version.ts
+++ b/dev-packages/cli/src/commands/releng/version.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 EclipseSource and others.
+ * Copyright (c) 2025-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/dev-packages/cli/src/commands/repo/build.spec.ts
+++ b/dev-packages/cli/src/commands/repo/build.spec.ts
@@ -1,0 +1,131 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as processUtil from '../../util/process-util';
+import { createTempDir, cleanupTempDir } from '../../../tests/helpers/test-helper';
+import { BuildActionOptions, buildSingleRepo, runBuildOrdered } from './build';
+
+describe('build-action', () => {
+    const sandbox = sinon.createSandbox();
+    let tempDir: string;
+    let execAsyncStub: sinon.SinonStub;
+
+    function makeOptions(overrides: Partial<BuildActionOptions> = {}): BuildActionOptions {
+        return {
+            dir: tempDir,
+            electron: false,
+            verbose: false,
+            failFast: true,
+            ...overrides
+        };
+    }
+
+    function createRepoDirs(...names: string[]): void {
+        for (const name of names) {
+            fs.mkdirSync(path.join(tempDir, name), { recursive: true });
+        }
+    }
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        execAsyncStub = sandbox.stub(processUtil, 'execAsync').resolves('');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        cleanupTempDir(tempDir);
+    });
+
+    describe('buildSingleRepo', () => {
+        it('should run yarn for standard npm repos', async () => {
+            createRepoDirs('glsp-client');
+            await buildSingleRepo('glsp-client', makeOptions());
+            expect(execAsyncStub.calledOnce).to.be.true;
+            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn');
+        });
+
+        it('should run yarn then yarn browser build for theia-integration', async () => {
+            createRepoDirs('glsp-theia-integration');
+            await buildSingleRepo('glsp-theia-integration', makeOptions());
+            expect(execAsyncStub.callCount).to.equal(2);
+            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn');
+            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn browser build');
+        });
+
+        it('should run yarn then yarn electron build with --electron', async () => {
+            createRepoDirs('glsp-theia-integration');
+            await buildSingleRepo('glsp-theia-integration', makeOptions({ electron: true }));
+            expect(execAsyncStub.callCount).to.equal(2);
+            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn electron build');
+        });
+
+        it('should run mvn for glsp-server', async () => {
+            createRepoDirs('glsp-server');
+            await buildSingleRepo('glsp-server', makeOptions());
+            expect(execAsyncStub.calledOnce).to.be.true;
+            expect(execAsyncStub.firstCall.args[0]).to.equal('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always');
+        });
+
+        it('should build client and server for eclipse-integration', async () => {
+            createRepoDirs('glsp-eclipse-integration');
+            await buildSingleRepo('glsp-eclipse-integration', makeOptions());
+            expect(execAsyncStub.callCount).to.equal(2);
+            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn');
+            expect(execAsyncStub.firstCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
+            expect(execAsyncStub.secondCall.args[0]).to.equal('mvn clean verify -Dstyle.color=always');
+            expect(execAsyncStub.secondCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'server'));
+        });
+    });
+
+    describe('runBuildOrdered', () => {
+        it('should build repos sequentially in dependency order', async () => {
+            createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
+            const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions());
+            expect(failures).to.equal(0);
+            expect(execAsyncStub.callCount).to.equal(3);
+        });
+
+        it('should error if a repo directory is missing', async () => {
+            createRepoDirs('glsp');
+            try {
+                await runBuildOrdered(['glsp', 'glsp-client'], makeOptions());
+                expect.fail('should have thrown');
+            } catch (error) {
+                expect((error as Error).message).to.contain('glsp-client');
+            }
+        });
+
+        it('should stop on first failure when failFast is true', async () => {
+            createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
+            execAsyncStub.onFirstCall().rejects(new Error('build failed'));
+            const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: true }));
+            expect(failures).to.equal(1);
+            expect(execAsyncStub.callCount).to.equal(1);
+        });
+
+        it('should continue on failure when failFast is false', async () => {
+            createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
+            execAsyncStub.onFirstCall().rejects(new Error('build failed'));
+            const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: false }));
+            expect(failures).to.equal(1);
+            expect(execAsyncStub.callCount).to.equal(3);
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/build.ts
+++ b/dev-packages/cli/src/commands/repo/build.ts
@@ -1,0 +1,180 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command, Option } from 'commander';
+import * as path from 'path';
+import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, execAsync } from '../../util';
+import { configureRepoEnv, formatError, getBuildOrder, resolveTargetRepos, resolveWorkspaceDir, validateReposExist } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export interface BuildActionOptions {
+    dir: string;
+    electron: boolean;
+    verbose: boolean;
+    failFast: boolean;
+}
+
+export async function buildSingleRepo(repo: GLSPRepo, options: BuildActionOptions): Promise<void> {
+    const repoDir = path.resolve(options.dir, repo);
+    const yarnOpts = { cwd: repoDir, verbose: options.verbose, silent: false, env: { FORCE_COLOR: '1' } };
+    const mvnOpts = { cwd: repoDir, verbose: options.verbose, silent: false };
+
+    LOGGER.label(`Building ${repo}...`);
+
+    switch (repo) {
+        case 'glsp-theia-integration': {
+            LOGGER.debug('Yarn install');
+            await execAsync('yarn', yarnOpts);
+            const target = options.electron ? 'electron' : 'browser';
+            LOGGER.debug('Yarn build for target: ' + target);
+            await execAsync(`yarn ${target} build`, yarnOpts);
+            break;
+        }
+        case 'glsp-server': {
+            await execAsync('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always', mvnOpts);
+            break;
+        }
+        case 'glsp-eclipse-integration': {
+            LOGGER.debug('Yarn build for client');
+            await execAsync('yarn', { ...yarnOpts, cwd: path.join(repoDir, 'client') });
+            LOGGER.debug('Maven build for server');
+            await execAsync('mvn clean verify -Dstyle.color=always', { ...mvnOpts, cwd: path.join(repoDir, 'server') });
+            break;
+        }
+        default: {
+            LOGGER.debug('Yarn build');
+            await execAsync('yarn', yarnOpts);
+            break;
+        }
+    }
+
+    LOGGER.info(`Successfully built ${repo}`);
+}
+
+export async function runBuildOrdered(repos: GLSPRepo[], options: BuildActionOptions): Promise<number> {
+    validateReposExist(repos, options.dir);
+
+    const ordered = getBuildOrder(repos);
+    let failures = 0;
+
+    for (let i = 0; i < ordered.length; i++) {
+        const repo = ordered[i];
+        try {
+            if (i > 0) {
+                LOGGER.newLine();
+            }
+            await buildSingleRepo(repo, options);
+        } catch (error) {
+            failures++;
+            LOGGER.error(`Building ${repo} failed: ${formatError(error)}`);
+            if (options.failFast) {
+                break;
+            }
+        }
+    }
+
+    return failures;
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface BuildCliOptions {
+    dir?: string;
+    electron: boolean;
+    verbose: boolean;
+}
+
+export function createScopedBuildCommand(repo: GLSPRepo): Command {
+    const cmd = baseCommand()
+        .name('build')
+        .description(`Build the ${repo} repository`)
+        .option('-d, --dir <path>', 'Target directory where repos are cloned')
+        .option('-v, --verbose', 'Verbose output', false);
+
+    if (repo === 'glsp-theia-integration') {
+        cmd.option('--electron', 'Build electron variant instead of browser', false);
+    }
+
+    cmd.action(async (_cmdOptions: BuildCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<BuildCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+
+        const options: BuildActionOptions = {
+            dir,
+            electron: cli.electron ?? false,
+            verbose: cli.verbose,
+            failFast: true
+        };
+
+        validateReposExist([repo], dir);
+        try {
+            await buildSingleRepo(repo, options);
+        } catch (error) {
+            LOGGER.error(`Building ${repo} failed: ${formatError(error)}`);
+            process.exitCode = 1;
+        }
+    });
+
+    return cmd;
+}
+
+interface TopLevelBuildCliOptions {
+    dir?: string;
+    electron: boolean;
+    verbose: boolean;
+    repo?: string[];
+    preset?: string;
+    java: boolean;
+    failFast: boolean;
+}
+
+export const BuildCommand = baseCommand()
+    .name('build')
+    .description('Build repositories (dependency-ordered)')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .addOption(new Option('-r, --repo <name...>', 'Build only these repos'))
+    .addOption(new Option('--preset <name>', 'Build repos from a preset').choices(PRESET_NAMES))
+    .option('--electron', 'Build Theia electron variant instead of browser', false)
+    .option('--no-java', 'Skip repositories that require Java/Maven')
+    .option('--no-fail-fast', 'Continue building after a failure')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: TopLevelBuildCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<TopLevelBuildCliOptions>();
+        configureRepoEnv(cli);
+
+        const { dir, repos: allRepos } = resolveTargetRepos(cli);
+
+        let repos = allRepos;
+
+        if (!cli.java) {
+            repos = repos.filter(r => GLSPRepo.isNpmRepo(r));
+        }
+
+        const options: BuildActionOptions = {
+            dir,
+            electron: cli.electron,
+            verbose: cli.verbose,
+            failFast: cli.failFast
+        };
+
+        const failures = await runBuildOrdered(repos, options);
+        if (failures > 0) {
+            process.exitCode = 1;
+        }
+    });

--- a/dev-packages/cli/src/commands/repo/clone.spec.ts
+++ b/dev-packages/cli/src/commands/repo/clone.spec.ts
@@ -1,0 +1,137 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as processUtil from '../../util/process-util';
+import * as forkUtils from './common/fork-utils';
+import { createTempDir, cleanupTempDir } from '../../../tests/helpers/test-helper';
+import { CloneActionOptions, cloneSingleRepo } from './clone';
+
+describe('clone-action', () => {
+    const sandbox = sinon.createSandbox();
+    let tempDir: string;
+    let execStub: sinon.SinonStub;
+
+    function makeOptions(overrides: Partial<CloneActionOptions> = {}): CloneActionOptions {
+        return {
+            dir: tempDir,
+            protocol: 'https',
+            verbose: false,
+            ...overrides
+        };
+    }
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        execStub = sandbox.stub(processUtil, 'exec').returns('');
+        sandbox.stub(forkUtils, 'ensureFork').resolves();
+        sandbox.stub(forkUtils, 'getRemotes').returns({});
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        cleanupTempDir(tempDir);
+    });
+
+    describe('cloneSingleRepo', () => {
+        it('should call git clone with https URL', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions());
+            expect(execStub.calledOnce).to.be.true;
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('git clone');
+            expect(cmd).to.contain('https://github.com/eclipse-glsp/glsp-client.git');
+            expect(cmd).to.contain(path.join(tempDir, 'glsp-client'));
+        });
+
+        it('should call git clone with ssh URL', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ protocol: 'ssh' }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('git@github.com:eclipse-glsp/glsp-client.git');
+        });
+
+        it('should use fork org when --fork is set', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('myuser/glsp-client');
+        });
+
+        it('should add upstream remote when --fork is set', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
+            const upstreamCall = execStub.getCalls().find(c => (c.args[0] as string).includes('remote add upstream'));
+            expect(upstreamCall).to.exist;
+            expect(upstreamCall!.args[0]).to.contain('eclipse-glsp/glsp-client');
+        });
+
+        it('should not add upstream if already present after clone', async () => {
+            (forkUtils.getRemotes as sinon.SinonStub).returns({ upstream: 'https://github.com/eclipse-glsp/glsp-client.git' });
+            await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
+            const upstreamCall = execStub.getCalls().find(c => (c.args[0] as string).includes('remote add upstream'));
+            expect(upstreamCall).to.be.undefined;
+        });
+
+        it('should call ensureFork when --fork is set', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
+            expect((forkUtils.ensureFork as sinon.SinonStub).calledOnceWith('myuser', 'glsp-client')).to.be.true;
+        });
+
+        it('should not call ensureFork when --fork is not set', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions());
+            expect((forkUtils.ensureFork as sinon.SinonStub).called).to.be.false;
+        });
+
+        it('should include -b flag when --branch is set', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ branch: 'release/2.0' }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('-b release/2.0');
+        });
+
+        it('should skip when target directory exists and no --override', async () => {
+            fs.mkdirSync(path.join(tempDir, 'glsp-client'));
+            const result = await cloneSingleRepo('glsp-client', makeOptions());
+            expect(result).to.be.false;
+            expect(execStub.called).to.be.false;
+        });
+
+        it('should remove existing directory with --override remove', async () => {
+            const targetDir = path.join(tempDir, 'glsp-client');
+            fs.mkdirSync(targetDir);
+            fs.writeFileSync(path.join(targetDir, 'old.txt'), 'old');
+            await cloneSingleRepo('glsp-client', makeOptions({ override: 'remove' }));
+            expect(fs.existsSync(path.join(targetDir, 'old.txt'))).to.be.false;
+            expect(execStub.calledOnce).to.be.true;
+        });
+
+        it('should rename existing directory with --override rename', async () => {
+            const targetDir = path.join(tempDir, 'glsp-client');
+            fs.mkdirSync(targetDir);
+            fs.writeFileSync(path.join(targetDir, 'marker.txt'), 'original');
+            await cloneSingleRepo('glsp-client', makeOptions({ override: 'rename' }));
+            const entries = fs.readdirSync(tempDir).filter(e => e.startsWith('glsp-client_'));
+            expect(entries).to.have.lengthOf(1);
+            expect(fs.readFileSync(path.join(tempDir, entries[0], 'marker.txt'), 'utf-8')).to.equal('original');
+        });
+
+        it('should use gh repo clone for gh protocol', async () => {
+            await cloneSingleRepo('glsp-client', makeOptions({ protocol: 'gh' }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('gh repo clone');
+            expect(cmd).to.contain('eclipse-glsp/glsp-client');
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/clone.ts
+++ b/dev-packages/cli/src/commands/repo/clone.ts
@@ -1,0 +1,263 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { Command, Option } from 'commander';
+import {
+    GLSPRepo,
+    LOGGER,
+    PRESETS,
+    PRESET_NAMES,
+    baseCommand,
+    checkGHCli,
+    exec,
+    resolveDefaultProtocol,
+    resolveRepoFilter
+} from '../../util';
+import { addUpstreamRemote, ensureFork, getRemoteUrl, getRemotes } from './common/fork-utils';
+import { GLSP_GITHUB_ORG, configureRepoEnv, formatError, resolveWorkspaceDir } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export interface CloneActionOptions {
+    dir: string;
+    protocol: 'ssh' | 'https' | 'gh';
+    branch?: string;
+    fork?: string;
+    override?: 'rename' | 'remove';
+    verbose: boolean;
+}
+
+export async function cloneSingleRepo(repo: GLSPRepo, options: CloneActionOptions): Promise<boolean> {
+    const targetDir = path.resolve(options.dir, repo);
+
+    if (fs.existsSync(targetDir)) {
+        if (!options.override) {
+            LOGGER.warn(`Skipping ${repo}: target directory already exists (use --override to replace): ${targetDir}`);
+            return false;
+        }
+        if (options.override === 'rename') {
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const renamed = `${targetDir}_${timestamp}`;
+            LOGGER.info(`Renaming existing directory ${targetDir} → ${renamed}`);
+            fs.renameSync(targetDir, renamed);
+        } else if (options.override === 'remove') {
+            LOGGER.info(`Removing existing directory ${targetDir}`);
+            fs.rmSync(targetDir, { recursive: true, force: true });
+        }
+    }
+
+    if (options.fork) {
+        await ensureFork(options.fork, repo);
+    }
+
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+
+    const org = options.fork ?? GLSP_GITHUB_ORG;
+    LOGGER.info(`Cloning ${org}/${repo} into ${targetDir}`);
+
+    if (options.protocol === 'gh') {
+        const branchArgs = options.branch ? ` -- -b ${options.branch}` : '';
+        exec(`gh repo clone ${org}/${repo} ${targetDir}${branchArgs}`);
+    } else {
+        const branchArg = options.branch ? ` -b ${options.branch}` : '';
+        const url = getRemoteUrl(options.protocol, org, repo);
+        exec(`git clone${branchArg} ${url} ${targetDir}`);
+    }
+
+    if (options.fork) {
+        const remotes = getRemotes(targetDir);
+        if (!remotes.upstream) {
+            addUpstreamRemote(targetDir, repo, options.protocol);
+        }
+    }
+
+    return true;
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface CloneCliOptions {
+    dir?: string;
+    protocol?: 'ssh' | 'https' | 'gh';
+    branch?: string;
+    fork?: string;
+    override?: 'rename' | 'remove';
+    interactive: boolean;
+    preset?: string;
+    failFast: boolean;
+    verbose: boolean;
+}
+
+export function createScopedCloneCommand(repo: GLSPRepo): Command {
+    const cmd = baseCommand()
+        .name('clone')
+        .description(`Clone the ${repo} repository`)
+        .option('-d, --dir <path>', 'Target directory for repo clones')
+        .addOption(new Option('-p, --protocol <protocol>', 'Git clone protocol (default: gh|https)').choices(['ssh', 'https', 'gh']))
+        .option('-b, --branch <name>', 'Branch or tag to check out after cloning')
+        .option('--fork <user>', 'Clone from a fork (replaces eclipse-glsp org)')
+        .addOption(new Option('--override <mode>', 'How to handle an existing target directory').choices(['rename', 'remove']))
+        .option('-v, --verbose', 'Verbose output', false);
+
+    cmd.action(async (_cmdOptions: CloneCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<CloneCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const protocol = cli.protocol ?? resolveDefaultProtocol();
+
+        if (protocol === 'gh') {
+            checkGHCli();
+        }
+
+        const options: CloneActionOptions = {
+            dir,
+            protocol,
+            branch: cli.branch,
+            fork: cli.fork,
+            override: cli.override,
+            verbose: cli.verbose
+        };
+
+        try {
+            await cloneSingleRepo(repo, options);
+        } catch (error) {
+            LOGGER.error(`Cloning ${repo} failed: ${formatError(error)}`);
+            process.exitCode = 1;
+        }
+    });
+
+    return cmd;
+}
+
+export const CloneCommand = baseCommand()
+    .name('clone')
+    .description('Clone GLSP repositories')
+    .argument('[repos...]', 'Repositories to clone (can combine with --preset)')
+    .option('-d, --dir <path>', 'Target directory for repo clones')
+    .addOption(new Option('-p, --protocol <protocol>', 'Git clone protocol (default: gh|https)').choices(['ssh', 'https', 'gh']))
+    .option('-b, --branch <name>', 'Branch or tag to check out after cloning')
+    .option('--fork <user>', 'Clone from a fork and set up dual-remote (origin=fork, upstream=eclipse-glsp)')
+    .addOption(new Option('--override <mode>', 'How to handle an existing target directory').choices(['rename', 'remove']))
+    .addOption(new Option('--preset <name>', 'Clone repos from a preset').choices(PRESET_NAMES))
+    .option('-i, --interactive', 'Guided setup: choose preset, protocol, and fork interactively', false)
+    .option('--no-fail-fast', 'Continue cloning after a failure')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (repos: string[], _cmdOptions: CloneCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<CloneCliOptions>();
+        configureRepoEnv(cli);
+
+        let resolvedRepos: GLSPRepo[];
+        let protocol: 'ssh' | 'https' | 'gh';
+        let fork: string | undefined;
+
+        if (cli.interactive) {
+            const answers = await runInteractiveClone();
+            resolvedRepos = resolveRepoFilter(GLSPRepo.choices as unknown as GLSPRepo[], {
+                repo: repos.length > 0 ? repos : undefined,
+                preset: answers.preset
+            });
+            protocol = cli.protocol ?? answers.protocol ?? resolveDefaultProtocol();
+            fork = cli.fork ?? answers.fork;
+        } else {
+            if (repos.length === 0 && !cli.preset) {
+                throw new Error(
+                    'Specify repositories to clone, use --preset, or use --interactive for guided setup.\n' +
+                        `Available presets: ${PRESET_NAMES.join(', ')}`
+                );
+            }
+            resolvedRepos = resolveRepoFilter(GLSPRepo.choices as unknown as GLSPRepo[], {
+                repo: repos.length > 0 ? repos : undefined,
+                preset: cli.preset
+            });
+            protocol = cli.protocol ?? resolveDefaultProtocol();
+            fork = cli.fork;
+        }
+
+        const dir = resolveWorkspaceDir(cli.dir);
+
+        if (protocol === 'gh' || fork) {
+            checkGHCli();
+        }
+
+        const options: CloneActionOptions = {
+            dir,
+            protocol,
+            branch: cli.branch,
+            fork,
+            override: cli.override,
+            verbose: cli.verbose
+        };
+
+        let failures = 0;
+        for (const repo of resolvedRepos) {
+            try {
+                await cloneSingleRepo(repo, options);
+            } catch (error) {
+                failures++;
+                LOGGER.error(`Cloning ${repo} failed: ${formatError(error)}`);
+                if (cli.failFast) {
+                    break;
+                }
+            }
+        }
+
+        if (failures > 0) {
+            process.exitCode = 1;
+        }
+    });
+
+// ── Interactive setup ──────────────────────────────────────────────────────
+
+interface InteractiveAnswers {
+    preset: string;
+    protocol?: 'ssh' | 'https' | 'gh';
+    fork?: string;
+}
+
+async function runInteractiveClone(): Promise<InteractiveAnswers> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const ask = (question: string): Promise<string> => new Promise(resolve => rl.question(question, resolve));
+
+    try {
+        console.log('Available presets:');
+        for (const [name, repos] of Object.entries(PRESETS)) {
+            console.log(`  ${name}: ${repos.join(', ')}`);
+        }
+
+        const preset = await ask(`\nPreset (${PRESET_NAMES.join('/')}): `);
+        if (!PRESET_NAMES.includes(preset)) {
+            throw new Error(`Unknown preset: ${preset}. Must be one of: ${PRESET_NAMES.join(', ')}`);
+        }
+
+        const defaultProtocol = resolveDefaultProtocol();
+        const protocolInput = await ask(`Clone protocol (ssh/https/gh) [${defaultProtocol}]: `);
+        const protocol = protocolInput ? (protocolInput as 'ssh' | 'https' | 'gh') : undefined;
+
+        const fork = await ask('Fork user (leave empty for eclipse-glsp): ');
+
+        return {
+            preset,
+            protocol,
+            fork: fork || undefined
+        };
+    } finally {
+        rl.close();
+    }
+}

--- a/dev-packages/cli/src/commands/repo/clone.ts
+++ b/dev-packages/cli/src/commands/repo/clone.ts
@@ -16,7 +16,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as readline from 'readline';
 import { Command, Option } from 'commander';
 import {
     GLSPRepo,
@@ -30,7 +29,7 @@ import {
     resolveRepoFilter
 } from '../../util';
 import { addUpstreamRemote, ensureFork, getRemoteUrl, getRemotes } from './common/fork-utils';
-import { GLSP_GITHUB_ORG, configureRepoEnv, formatError, resolveWorkspaceDir } from './common/utils';
+import { GLSP_GITHUB_ORG, configureRepoEnv, formatError, prompt, resolveWorkspaceDir } from './common/utils';
 
 // ── Action ──────────────────────────────────────────────────────────────────
 
@@ -73,11 +72,11 @@ export async function cloneSingleRepo(repo: GLSPRepo, options: CloneActionOption
 
     if (options.protocol === 'gh') {
         const branchArgs = options.branch ? ` -- -b ${options.branch}` : '';
-        exec(`gh repo clone ${org}/${repo} ${targetDir}${branchArgs}`);
+        exec(`gh repo clone ${org}/${repo} "${targetDir}"${branchArgs}`);
     } else {
         const branchArg = options.branch ? ` -b ${options.branch}` : '';
         const url = getRemoteUrl(options.protocol, org, repo);
-        exec(`git clone${branchArg} ${url} ${targetDir}`);
+        exec(`git clone${branchArg} ${url} "${targetDir}"`);
     }
 
     if (options.fork) {
@@ -169,7 +168,7 @@ export const CloneCommand = baseCommand()
 
         if (cli.interactive) {
             const answers = await runInteractiveClone();
-            resolvedRepos = resolveRepoFilter(GLSPRepo.choices as unknown as GLSPRepo[], {
+            resolvedRepos = resolveRepoFilter(GLSPRepo.choices, {
                 repo: repos.length > 0 ? repos : undefined,
                 preset: answers.preset
             });
@@ -182,7 +181,7 @@ export const CloneCommand = baseCommand()
                         `Available presets: ${PRESET_NAMES.join(', ')}`
                 );
             }
-            resolvedRepos = resolveRepoFilter(GLSPRepo.choices as unknown as GLSPRepo[], {
+            resolvedRepos = resolveRepoFilter(GLSPRepo.choices, {
                 repo: repos.length > 0 ? repos : undefined,
                 preset: cli.preset
             });
@@ -206,9 +205,13 @@ export const CloneCommand = baseCommand()
         };
 
         let failures = 0;
+        let skipped = 0;
         for (const repo of resolvedRepos) {
             try {
-                await cloneSingleRepo(repo, options);
+                const cloned = await cloneSingleRepo(repo, options);
+                if (!cloned) {
+                    skipped++;
+                }
             } catch (error) {
                 failures++;
                 LOGGER.error(`Cloning ${repo} failed: ${formatError(error)}`);
@@ -218,6 +221,9 @@ export const CloneCommand = baseCommand()
             }
         }
 
+        if (skipped > 0) {
+            LOGGER.info(`${skipped} repo(s) skipped (already exist).`);
+        }
         if (failures > 0) {
             process.exitCode = 1;
         }
@@ -232,32 +238,25 @@ interface InteractiveAnswers {
 }
 
 async function runInteractiveClone(): Promise<InteractiveAnswers> {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const ask = (question: string): Promise<string> => new Promise(resolve => rl.question(question, resolve));
-
-    try {
-        console.log('Available presets:');
-        for (const [name, repos] of Object.entries(PRESETS)) {
-            console.log(`  ${name}: ${repos.join(', ')}`);
-        }
-
-        const preset = await ask(`\nPreset (${PRESET_NAMES.join('/')}): `);
-        if (!PRESET_NAMES.includes(preset)) {
-            throw new Error(`Unknown preset: ${preset}. Must be one of: ${PRESET_NAMES.join(', ')}`);
-        }
-
-        const defaultProtocol = resolveDefaultProtocol();
-        const protocolInput = await ask(`Clone protocol (ssh/https/gh) [${defaultProtocol}]: `);
-        const protocol = protocolInput ? (protocolInput as 'ssh' | 'https' | 'gh') : undefined;
-
-        const fork = await ask('Fork user (leave empty for eclipse-glsp): ');
-
-        return {
-            preset,
-            protocol,
-            fork: fork || undefined
-        };
-    } finally {
-        rl.close();
+    console.log('Available presets:');
+    for (const [name, repos] of Object.entries(PRESETS)) {
+        console.log(`  ${name}: ${repos.join(', ')}`);
     }
+
+    const preset = await prompt(`\nPreset (${PRESET_NAMES.join('/')}): `);
+    if (!PRESET_NAMES.includes(preset)) {
+        throw new Error(`Unknown preset: ${preset}. Must be one of: ${PRESET_NAMES.join(', ')}`);
+    }
+
+    const defaultProtocol = resolveDefaultProtocol();
+    const protocolInput = await prompt(`Clone protocol (ssh/https/gh) [${defaultProtocol}]: `);
+    const protocol = protocolInput ? (protocolInput as 'ssh' | 'https' | 'gh') : undefined;
+
+    const fork = await prompt('Fork user (leave empty for eclipse-glsp): ');
+
+    return {
+        preset,
+        protocol,
+        fork: fork || undefined
+    };
 }

--- a/dev-packages/cli/src/commands/repo/common/fork-utils.ts
+++ b/dev-packages/cli/src/commands/repo/common/fork-utils.ts
@@ -1,0 +1,119 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as readline from 'readline';
+import { GLSPRepo, LOGGER, exec, isGithubCLIAuthenticated } from '../../../util';
+import { GLSP_GITHUB_ORG } from './utils';
+
+// ── Fork existence ─────────────────────────────────────────────────────────
+
+export function forkExists(user: string, repo: GLSPRepo): boolean {
+    try {
+        exec(`git ls-remote https://github.com/${user}/${repo}.git HEAD`, { silent: true });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function ensureFork(user: string, repo: GLSPRepo): Promise<void> {
+    if (forkExists(user, repo)) {
+        return;
+    }
+    if (!isGithubCLIAuthenticated()) {
+        throw new Error(`Fork '${user}/${repo}' not found. Install and authenticate the GitHub CLI (gh) to auto-create forks.`);
+    }
+    const confirmed = await confirm(`Fork '${user}/${repo}' does not exist. Create it?`);
+    if (!confirmed) {
+        throw new Error(`Fork creation declined for '${user}/${repo}'.`);
+    }
+    LOGGER.info(`Creating fork ${user}/${repo}...`);
+    exec(`gh repo fork ${GLSP_GITHUB_ORG}/${repo} --remote=false`);
+}
+
+// ── Remote helpers ─────────────────────────────────────────────────────────
+
+export function getRemoteUrl(protocol: 'ssh' | 'https' | 'gh', org: string, repo: string): string {
+    if (protocol === 'ssh') {
+        return `git@github.com:${org}/${repo}.git`;
+    }
+    return `https://github.com/${org}/${repo}.git`;
+}
+
+export function addUpstreamRemote(repoDir: string, repo: GLSPRepo, protocol: 'ssh' | 'https' | 'gh'): void {
+    const url = getRemoteUrl(protocol, GLSP_GITHUB_ORG, repo);
+    LOGGER.info(`Adding upstream remote: ${url}`);
+    exec(`git remote add upstream ${url}`, { cwd: repoDir });
+}
+
+export interface RemoteInfo {
+    origin?: string;
+    upstream?: string;
+}
+
+export function getRemotes(repoDir: string): RemoteInfo {
+    const result: RemoteInfo = {};
+    try {
+        result.origin = exec('git config --get remote.origin.url', { cwd: repoDir, silent: true });
+    } catch {
+        /* empty */
+    }
+    try {
+        result.upstream = exec('git config --get remote.upstream.url', { cwd: repoDir, silent: true });
+    } catch {
+        /* empty */
+    }
+    return result;
+}
+
+export function remoteMatchesOrg(url: string, org: string, repo: string): boolean {
+    return url.includes(`${org}/${repo}`);
+}
+
+// ── Remote analysis ────────────────────────────────────────────────────────
+
+export type ForkAction = 'already-configured' | 'rename-origin' | 'set-origin' | 'unexpected';
+
+export function analyzeForkRemotes(remotes: RemoteInfo, forkUser: string, repo: GLSPRepo): ForkAction {
+    const originIsFork = remotes.origin !== undefined && remoteMatchesOrg(remotes.origin, forkUser, repo);
+    const originIsEclipse = remotes.origin !== undefined && remoteMatchesOrg(remotes.origin, GLSP_GITHUB_ORG, repo);
+    const upstreamIsEclipse = remotes.upstream !== undefined && remoteMatchesOrg(remotes.upstream, GLSP_GITHUB_ORG, repo);
+
+    if (originIsFork && upstreamIsEclipse) {
+        return 'already-configured';
+    }
+
+    if (originIsEclipse) {
+        if (!remotes.upstream || upstreamIsEclipse) {
+            return remotes.upstream ? 'set-origin' : 'rename-origin';
+        }
+        return 'unexpected';
+    }
+
+    return 'unexpected';
+}
+
+// ── Prompting ──────────────────────────────────────────────────────────────
+
+export async function confirm(message: string): Promise<boolean> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+        const answer = await new Promise<string>(resolve => rl.question(`${message} [y/N] `, resolve));
+        return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    } finally {
+        rl.close();
+    }
+}

--- a/dev-packages/cli/src/commands/repo/common/fork-utils.ts
+++ b/dev-packages/cli/src/commands/repo/common/fork-utils.ts
@@ -14,9 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as readline from 'readline';
 import { GLSPRepo, LOGGER, exec, isGithubCLIAuthenticated } from '../../../util';
-import { GLSP_GITHUB_ORG } from './utils';
+import { GLSP_GITHUB_ORG, prompt } from './utils';
 
 // ── Fork existence ─────────────────────────────────────────────────────────
 
@@ -24,7 +23,11 @@ export function forkExists(user: string, repo: GLSPRepo): boolean {
     try {
         exec(`git ls-remote https://github.com/${user}/${repo}.git HEAD`, { silent: true });
         return true;
-    } catch {
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : '';
+        if (msg.includes('Could not resolve host') || msg.includes('unable to access')) {
+            throw new Error(`Network error while checking fork '${user}/${repo}': ${msg}`);
+        }
         return false;
     }
 }
@@ -56,7 +59,7 @@ export function getRemoteUrl(protocol: 'ssh' | 'https' | 'gh', org: string, repo
 export function addUpstreamRemote(repoDir: string, repo: GLSPRepo, protocol: 'ssh' | 'https' | 'gh'): void {
     const url = getRemoteUrl(protocol, GLSP_GITHUB_ORG, repo);
     LOGGER.info(`Adding upstream remote: ${url}`);
-    exec(`git remote add upstream ${url}`, { cwd: repoDir });
+    exec(`git remote add upstream "${url}"`, { cwd: repoDir });
 }
 
 export interface RemoteInfo {
@@ -109,11 +112,6 @@ export function analyzeForkRemotes(remotes: RemoteInfo, forkUser: string, repo: 
 // ── Prompting ──────────────────────────────────────────────────────────────
 
 export async function confirm(message: string): Promise<boolean> {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    try {
-        const answer = await new Promise<string>(resolve => rl.question(`${message} [y/N] `, resolve));
-        return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
-    } finally {
-        rl.close();
-    }
+    const answer = await prompt(`${message} [y/N] `);
+    return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
 }

--- a/dev-packages/cli/src/commands/repo/common/utils.spec.ts
+++ b/dev-packages/cli/src/commands/repo/common/utils.spec.ts
@@ -1,0 +1,218 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { GLSPRepo } from '../../../util';
+import { createTempDir, cleanupTempDir } from '../../../../tests/helpers/test-helper';
+import { discoverRepos, getBuildLevels, getBuildOrder, isLeafRepo, resolveWorkspaceDir } from './utils';
+
+// ── workspace-resolution ──────────────────────────────────────────────────
+
+describe('workspace-resolution', () => {
+    let tempDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        originalCwd = process.cwd();
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        cleanupTempDir(tempDir);
+    });
+
+    describe('resolveWorkspaceDir', () => {
+        it('should return the given directory when cliDir is provided', () => {
+            const dir = path.join(tempDir, 'my-workspace');
+            fs.mkdirSync(dir, { recursive: true });
+            const result = resolveWorkspaceDir(dir);
+            expect(result).to.equal(dir);
+        });
+
+        it('should resolve a relative cliDir against cwd', () => {
+            process.chdir(tempDir);
+            fs.mkdirSync(path.join(tempDir, 'sub'), { recursive: true });
+            const result = resolveWorkspaceDir('sub');
+            expect(result).to.equal(path.resolve(tempDir, 'sub'));
+        });
+
+        it('should return cwd when no cliDir and not inside a known repo', () => {
+            process.chdir(tempDir);
+            const result = resolveWorkspaceDir();
+            expect(result).to.equal(tempDir);
+        });
+
+        it('should return the parent of a known repo root when inside one', () => {
+            const repoDir = path.join(tempDir, 'glsp-client');
+            fs.mkdirSync(repoDir, { recursive: true });
+            process.chdir(repoDir);
+            const result = resolveWorkspaceDir();
+            expect(result).to.equal(tempDir);
+        });
+
+        it('should walk up from a nested directory inside a known repo', () => {
+            const repoDir = path.join(tempDir, 'glsp-client');
+            const nestedDir = path.join(repoDir, 'packages', 'client', 'src');
+            fs.mkdirSync(nestedDir, { recursive: true });
+            process.chdir(nestedDir);
+            const result = resolveWorkspaceDir();
+            expect(result).to.equal(tempDir);
+        });
+    });
+});
+
+// ── repo-discovery ────────────────────────────────────────────────────────
+
+describe('repo-discovery', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    describe('discoverRepos', () => {
+        it('should find known GLSP repo directories', () => {
+            fs.mkdirSync(path.join(tempDir, 'glsp-client'));
+            fs.mkdirSync(path.join(tempDir, 'glsp-server-node'));
+            const repos = discoverRepos(tempDir);
+            expect(repos).to.deep.equal(['glsp-server-node', 'glsp-client']);
+        });
+
+        it('should ignore non-GLSP directories', () => {
+            fs.mkdirSync(path.join(tempDir, 'glsp-client'));
+            fs.mkdirSync(path.join(tempDir, 'my-project'));
+            fs.mkdirSync(path.join(tempDir, 'node_modules'));
+            const repos = discoverRepos(tempDir);
+            expect(repos).to.deep.equal(['glsp-client']);
+        });
+
+        it('should ignore files matching GLSP repo names', () => {
+            fs.mkdirSync(path.join(tempDir, 'glsp-client'));
+            fs.writeFileSync(path.join(tempDir, 'glsp-server-node'), 'not a dir');
+            const repos = discoverRepos(tempDir);
+            expect(repos).to.deep.equal(['glsp-client']);
+        });
+
+        it('should return empty array for nonexistent directory', () => {
+            const repos = discoverRepos(path.join(tempDir, 'nonexistent'));
+            expect(repos).to.deep.equal([]);
+        });
+
+        it('should return repos sorted by GLSPRepo.choices order', () => {
+            fs.mkdirSync(path.join(tempDir, 'glsp-theia-integration'));
+            fs.mkdirSync(path.join(tempDir, 'glsp'));
+            fs.mkdirSync(path.join(tempDir, 'glsp-client'));
+            const repos = discoverRepos(tempDir);
+            expect(repos).to.deep.equal(['glsp', 'glsp-client', 'glsp-theia-integration']);
+        });
+
+        it('should return empty array when no GLSP repos exist', () => {
+            fs.mkdirSync(path.join(tempDir, 'some-project'));
+            const repos = discoverRepos(tempDir);
+            expect(repos).to.deep.equal([]);
+        });
+    });
+});
+
+// ── repo-graph ──────────────────────────────────────────────────────────────
+
+describe('repo-graph', () => {
+    describe('getBuildOrder', () => {
+        it('should return repos in dependency order', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node', 'glsp'];
+            const order = getBuildOrder(repos);
+            const glspIdx = order.indexOf('glsp');
+            const clientIdx = order.indexOf('glsp-client');
+            const serverNodeIdx = order.indexOf('glsp-server-node');
+            expect(glspIdx).to.be.lessThan(clientIdx);
+            expect(clientIdx).to.be.lessThan(serverNodeIdx);
+        });
+
+        it('should include only requested repos', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
+            const order = getBuildOrder(repos);
+            expect(order).to.have.lengthOf(2);
+            expect(order).to.include('glsp-client');
+            expect(order).to.include('glsp-server-node');
+        });
+
+        it('should handle independent repos', () => {
+            const repos: GLSPRepo[] = ['glsp-playwright'];
+            const order = getBuildOrder(repos);
+            expect(order).to.deep.equal(['glsp-playwright']);
+        });
+
+        it('should place glsp-server before glsp-eclipse-integration', () => {
+            const repos: GLSPRepo[] = ['glsp-eclipse-integration', 'glsp-server', 'glsp-client', 'glsp'];
+            const order = getBuildOrder(repos);
+            const serverIdx = order.indexOf('glsp-server');
+            const eclipseIdx = order.indexOf('glsp-eclipse-integration');
+            expect(serverIdx).to.be.lessThan(eclipseIdx);
+        });
+    });
+
+    describe('getBuildLevels', () => {
+        it('should group independent repos into the same level', () => {
+            const repos: GLSPRepo[] = ['glsp-server', 'glsp-playwright'];
+            const levels = getBuildLevels(repos);
+            expect(levels).to.have.lengthOf(1);
+            expect(levels[0]).to.include.members(['glsp-server', 'glsp-playwright']);
+        });
+
+        it('should separate dependent repos into sequential levels', () => {
+            const repos: GLSPRepo[] = ['glsp', 'glsp-client', 'glsp-server-node'];
+            const levels = getBuildLevels(repos);
+            expect(levels.length).to.be.greaterThanOrEqual(3);
+            expect(levels[0]).to.deep.equal(['glsp']);
+            expect(levels[1]).to.deep.equal(['glsp-client']);
+            expect(levels[2]).to.deep.equal(['glsp-server-node']);
+        });
+
+        it('should parallelize theia and vscode after server-node', () => {
+            const repos: GLSPRepo[] = ['glsp', 'glsp-client', 'glsp-server-node', 'glsp-theia-integration', 'glsp-vscode-integration'];
+            const levels = getBuildLevels(repos);
+            const lastLevel = levels[levels.length - 1];
+            expect(lastLevel).to.include.members(['glsp-theia-integration', 'glsp-vscode-integration']);
+        });
+
+        it('should handle single repo', () => {
+            const levels = getBuildLevels(['glsp-client']);
+            expect(levels).to.deep.equal([['glsp-client']]);
+        });
+    });
+
+    describe('isLeafRepo', () => {
+        it('should return true for repos that no other repo depends on', () => {
+            expect(isLeafRepo('glsp-theia-integration')).to.be.true;
+            expect(isLeafRepo('glsp-vscode-integration')).to.be.true;
+            expect(isLeafRepo('glsp-playwright')).to.be.true;
+        });
+
+        it('should return false for repos that are dependencies of other repos', () => {
+            expect(isLeafRepo('glsp')).to.be.false;
+            expect(isLeafRepo('glsp-client')).to.be.false;
+            expect(isLeafRepo('glsp-server-node')).to.be.false;
+            expect(isLeafRepo('glsp-server')).to.be.false;
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/common/utils.spec.ts
+++ b/dev-packages/cli/src/commands/repo/common/utils.spec.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { GLSPRepo } from '../../../util';
 import { createTempDir, cleanupTempDir } from '../../../../tests/helpers/test-helper';
-import { discoverRepos, getBuildLevels, getBuildOrder, isLeafRepo, resolveWorkspaceDir } from './utils';
+import { discoverRepos, getBuildOrder, isLeafRepo, resolveWorkspaceDir } from './utils';
 
 // ── workspace-resolution ──────────────────────────────────────────────────
 
@@ -168,36 +168,6 @@ describe('repo-graph', () => {
             const serverIdx = order.indexOf('glsp-server');
             const eclipseIdx = order.indexOf('glsp-eclipse-integration');
             expect(serverIdx).to.be.lessThan(eclipseIdx);
-        });
-    });
-
-    describe('getBuildLevels', () => {
-        it('should group independent repos into the same level', () => {
-            const repos: GLSPRepo[] = ['glsp-server', 'glsp-playwright'];
-            const levels = getBuildLevels(repos);
-            expect(levels).to.have.lengthOf(1);
-            expect(levels[0]).to.include.members(['glsp-server', 'glsp-playwright']);
-        });
-
-        it('should separate dependent repos into sequential levels', () => {
-            const repos: GLSPRepo[] = ['glsp', 'glsp-client', 'glsp-server-node'];
-            const levels = getBuildLevels(repos);
-            expect(levels.length).to.be.greaterThanOrEqual(3);
-            expect(levels[0]).to.deep.equal(['glsp']);
-            expect(levels[1]).to.deep.equal(['glsp-client']);
-            expect(levels[2]).to.deep.equal(['glsp-server-node']);
-        });
-
-        it('should parallelize theia and vscode after server-node', () => {
-            const repos: GLSPRepo[] = ['glsp', 'glsp-client', 'glsp-server-node', 'glsp-theia-integration', 'glsp-vscode-integration'];
-            const levels = getBuildLevels(repos);
-            const lastLevel = levels[levels.length - 1];
-            expect(lastLevel).to.include.members(['glsp-theia-integration', 'glsp-vscode-integration']);
-        });
-
-        it('should handle single repo', () => {
-            const levels = getBuildLevels(['glsp-client']);
-            expect(levels).to.deep.equal([['glsp-client']]);
         });
     });
 

--- a/dev-packages/cli/src/commands/repo/common/utils.ts
+++ b/dev-packages/cli/src/commands/repo/common/utils.ts
@@ -1,0 +1,165 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { GLSPRepo, configureEnv, globby, resolveRepoFilter } from '../../../util';
+
+export const GLSP_GITHUB_ORG = 'eclipse-glsp';
+export const THEIA_URL = 'http://localhost:3000';
+export const VSIX_TARGET_DIR = 'example/workflow/extension';
+
+export function configureRepoEnv(options: { verbose: boolean }): void {
+    configureEnv(options);
+}
+
+export function validateReposExist(repos: GLSPRepo[], dir: string): void {
+    const missing = repos.filter(repo => !fs.existsSync(path.resolve(dir, repo)));
+    if (missing.length > 0) {
+        throw new Error(`The following repositories are not cloned in '${dir}': ${missing.join(', ')}. Run 'glsp repo clone' first.`);
+    }
+}
+
+export function formatError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+// ── Workspace resolution ──────────────────────────────────────────────────
+
+export function resolveWorkspaceDir(cliDir?: string): string {
+    if (cliDir) {
+        return path.resolve(cliDir);
+    }
+
+    let current = path.resolve(process.cwd());
+    const root = path.parse(current).root;
+
+    while (current !== root) {
+        if (discoverRepos(current).length > 0) {
+            return current;
+        }
+        if (GLSPRepo.is(path.basename(current))) {
+            return path.dirname(current);
+        }
+        current = path.dirname(current);
+    }
+
+    return process.cwd();
+}
+
+// ── Repo discovery ────────────────────────────────────────────────────────
+
+export function discoverRepos(dir: string): GLSPRepo[] {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter(entry => entry.isDirectory() && GLSPRepo.is(entry.name))
+        .map(entry => entry.name as GLSPRepo)
+        .sort((a, b) => GLSPRepo.choices.indexOf(a) - GLSPRepo.choices.indexOf(b));
+}
+
+export interface ResolveTargetReposOptions {
+    dir?: string;
+    repo?: string[];
+    preset?: string;
+}
+
+export function resolveTargetRepos(options: ResolveTargetReposOptions): { dir: string; repos: GLSPRepo[] } {
+    const dir = resolveWorkspaceDir(options.dir);
+    const discovered = discoverRepos(dir);
+    if (discovered.length === 0) {
+        throw new Error(`No GLSP repositories found in '${dir}'. Clone repositories first with 'glsp repo clone'.`);
+    }
+    const repos = resolveRepoFilter(discovered, { repo: options.repo, preset: options.preset });
+    return { dir, repos };
+}
+
+// ── Dependency graph ────────────────────────────────────────────────────────
+
+const DEPENDENCY_MAP: Partial<Record<GLSPRepo, GLSPRepo[]>> = {
+    'glsp-client': ['glsp'],
+    'glsp-server-node': ['glsp-client'],
+    'glsp-theia-integration': ['glsp-server-node'],
+    'glsp-vscode-integration': ['glsp-server-node'],
+    'glsp-eclipse-integration': ['glsp-client', 'glsp-server']
+};
+
+export function getBuildOrder(repos: GLSPRepo[]): GLSPRepo[] {
+    const repoSet = new Set(repos);
+    const visited = new Set<GLSPRepo>();
+    const result: GLSPRepo[] = [];
+
+    function visit(repo: GLSPRepo): void {
+        if (visited.has(repo) || !repoSet.has(repo)) {
+            return;
+        }
+        visited.add(repo);
+        const deps = DEPENDENCY_MAP[repo] ?? [];
+        for (const dep of deps) {
+            visit(dep);
+        }
+        result.push(repo);
+    }
+
+    for (const repo of repos) {
+        visit(repo);
+    }
+    return result;
+}
+
+export function getBuildLevels(repos: GLSPRepo[]): GLSPRepo[][] {
+    const repoSet = new Set(repos);
+    const levels: GLSPRepo[][] = [];
+    const placed = new Set<GLSPRepo>();
+
+    while (placed.size < repoSet.size) {
+        const level: GLSPRepo[] = [];
+        for (const repo of repoSet) {
+            if (placed.has(repo)) {
+                continue;
+            }
+            const deps = (DEPENDENCY_MAP[repo] ?? []).filter(d => repoSet.has(d));
+            if (deps.every(d => placed.has(d))) {
+                level.push(repo);
+            }
+        }
+        for (const repo of level) {
+            placed.add(repo);
+        }
+        levels.push(level);
+    }
+
+    return levels;
+}
+
+export function isLeafRepo(repo: GLSPRepo): boolean {
+    for (const deps of Object.values(DEPENDENCY_MAP)) {
+        if (deps.includes(repo)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function discoverNewestFile(pattern: string, dir: string, errorMsg: string): string {
+    const files = globby(pattern, { cwd: dir, absolute: true });
+    if (files.length === 0) {
+        throw new Error(errorMsg);
+    }
+    return files.reduce((newest, file) => (fs.statSync(file).mtimeMs > fs.statSync(newest).mtimeMs ? file : newest));
+}

--- a/dev-packages/cli/src/commands/repo/common/utils.ts
+++ b/dev-packages/cli/src/commands/repo/common/utils.ts
@@ -16,6 +16,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as readline from 'readline';
 import { GLSPRepo, configureEnv, globby, resolveRepoFilter } from '../../../util';
 
 export const GLSP_GITHUB_ORG = 'eclipse-glsp';
@@ -122,31 +123,6 @@ export function getBuildOrder(repos: GLSPRepo[]): GLSPRepo[] {
     return result;
 }
 
-export function getBuildLevels(repos: GLSPRepo[]): GLSPRepo[][] {
-    const repoSet = new Set(repos);
-    const levels: GLSPRepo[][] = [];
-    const placed = new Set<GLSPRepo>();
-
-    while (placed.size < repoSet.size) {
-        const level: GLSPRepo[] = [];
-        for (const repo of repoSet) {
-            if (placed.has(repo)) {
-                continue;
-            }
-            const deps = (DEPENDENCY_MAP[repo] ?? []).filter(d => repoSet.has(d));
-            if (deps.every(d => placed.has(d))) {
-                level.push(repo);
-            }
-        }
-        for (const repo of level) {
-            placed.add(repo);
-        }
-        levels.push(level);
-    }
-
-    return levels;
-}
-
 export function isLeafRepo(repo: GLSPRepo): boolean {
     for (const deps of Object.values(DEPENDENCY_MAP)) {
         if (deps.includes(repo)) {
@@ -154,6 +130,18 @@ export function isLeafRepo(repo: GLSPRepo): boolean {
         }
     }
     return true;
+}
+
+// ── Prompting ──────────────────────────────────────────────────────────────
+
+export function prompt(question: string): Promise<string> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise<string>(resolve =>
+        rl.question(question, answer => {
+            rl.close();
+            resolve(answer);
+        })
+    );
 }
 
 export function discoverNewestFile(pattern: string, dir: string, errorMsg: string): string {

--- a/dev-packages/cli/src/commands/repo/fork.spec.ts
+++ b/dev-packages/cli/src/commands/repo/fork.spec.ts
@@ -1,0 +1,254 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as processUtil from '../../util/process-util';
+import * as forkUtils from './common/fork-utils';
+import { RemoteInfo, analyzeForkRemotes, getRemoteUrl, remoteMatchesOrg } from './common/fork-utils';
+import { createTempDir, cleanupTempDir } from '../../../tests/helpers/test-helper';
+import { configureForkRemote } from './fork';
+
+describe('fork-utils', () => {
+    describe('getRemoteUrl', () => {
+        it('should return SSH URL for ssh protocol', () => {
+            expect(getRemoteUrl('ssh', 'myuser', 'glsp-client')).to.equal('git@github.com:myuser/glsp-client.git');
+        });
+
+        it('should return HTTPS URL for https protocol', () => {
+            expect(getRemoteUrl('https', 'myuser', 'glsp-client')).to.equal('https://github.com/myuser/glsp-client.git');
+        });
+
+        it('should return HTTPS URL for gh protocol', () => {
+            expect(getRemoteUrl('gh', 'myuser', 'glsp-client')).to.equal('https://github.com/myuser/glsp-client.git');
+        });
+    });
+
+    describe('remoteMatchesOrg', () => {
+        it('should match HTTPS URL', () => {
+            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.true;
+        });
+
+        it('should match SSH URL', () => {
+            expect(remoteMatchesOrg('git@github.com:eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.true;
+        });
+
+        it('should not match different org', () => {
+            expect(remoteMatchesOrg('https://github.com/myuser/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.false;
+        });
+
+        it('should not match different repo', () => {
+            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-server-node.git', 'eclipse-glsp', 'glsp-client')).to.be.false;
+        });
+    });
+
+    describe('analyzeForkRemotes', () => {
+        const forkUser = 'myuser';
+        const repo = 'glsp-client';
+
+        it('should return already-configured when origin=fork and upstream=eclipse-glsp', () => {
+            const remotes: RemoteInfo = {
+                origin: 'git@github.com:myuser/glsp-client.git',
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('already-configured');
+        });
+
+        it('should return rename-origin when origin=eclipse-glsp and no upstream', () => {
+            const remotes: RemoteInfo = {
+                origin: 'https://github.com/eclipse-glsp/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('rename-origin');
+        });
+
+        it('should return set-origin when origin=eclipse-glsp and upstream=eclipse-glsp', () => {
+            const remotes: RemoteInfo = {
+                origin: 'https://github.com/eclipse-glsp/glsp-client.git',
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('set-origin');
+        });
+
+        it('should return unexpected when origin=eclipse-glsp and upstream=something-else', () => {
+            const remotes: RemoteInfo = {
+                origin: 'https://github.com/eclipse-glsp/glsp-client.git',
+                upstream: 'https://github.com/other-org/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+        });
+
+        it('should return unexpected when origin is unknown org', () => {
+            const remotes: RemoteInfo = {
+                origin: 'https://github.com/other-org/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+        });
+
+        it('should return unexpected when no remotes exist', () => {
+            const remotes: RemoteInfo = {};
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+        });
+
+        it('should return unexpected when only upstream exists', () => {
+            const remotes: RemoteInfo = {
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+        });
+
+        it('should handle SSH URLs for eclipse-glsp origin', () => {
+            const remotes: RemoteInfo = {
+                origin: 'git@github.com:eclipse-glsp/glsp-client.git'
+            };
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('rename-origin');
+        });
+    });
+});
+
+describe('fork-action', () => {
+    const sandbox = sinon.createSandbox();
+    let tempDir: string;
+    let execStub: sinon.SinonStub;
+    let ensureForkStub: sinon.SinonStub;
+    let getRemotesStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        execStub = sandbox.stub(processUtil, 'exec').returns('');
+        ensureForkStub = sandbox.stub(forkUtils, 'ensureFork').resolves();
+        getRemotesStub = sandbox.stub(forkUtils, 'getRemotes');
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        cleanupTempDir(tempDir);
+    });
+
+    function createRepoDir(repo: string): string {
+        const repoDir = path.join(tempDir, repo);
+        fs.mkdirSync(repoDir, { recursive: true });
+        return repoDir;
+    }
+
+    describe('configureForkRemote', () => {
+        it('should rename origin and add fork for rename-origin flow', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({ origin: 'https://github.com/eclipse-glsp/glsp-client.git' });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'ssh');
+
+            expect(ensureForkStub.calledOnceWith('myuser', 'glsp-client')).to.be.true;
+            const calls = execStub.getCalls().map(c => c.args[0] as string);
+            expect(calls).to.include('git remote rename origin upstream');
+            const addOrigin = calls.find(c => c.includes('git remote add origin'));
+            expect(addOrigin).to.exist;
+            expect(addOrigin).to.contain('git@github.com:myuser/glsp-client.git');
+        });
+
+        it('should set origin URL for set-origin flow', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({
+                origin: 'https://github.com/eclipse-glsp/glsp-client.git',
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'https');
+
+            expect(ensureForkStub.calledOnceWith('myuser', 'glsp-client')).to.be.true;
+            const calls = execStub.getCalls().map(c => c.args[0] as string);
+            const setUrl = calls.find(c => c.includes('git remote set-url origin'));
+            expect(setUrl).to.exist;
+            expect(setUrl).to.contain('https://github.com/myuser/glsp-client.git');
+        });
+
+        it('should skip when already configured', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({
+                origin: 'git@github.com:myuser/glsp-client.git',
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'ssh');
+
+            expect(ensureForkStub.called).to.be.false;
+            expect(execStub.called).to.be.false;
+        });
+
+        it('should skip when remotes are unexpected', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({ origin: 'https://github.com/other-org/glsp-client.git' });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'ssh');
+
+            expect(ensureForkStub.called).to.be.false;
+            expect(execStub.called).to.be.false;
+        });
+
+        it('should use ssh URL when protocol is ssh', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({ origin: 'https://github.com/eclipse-glsp/glsp-client.git' });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'ssh');
+
+            const addOrigin = execStub.getCalls().find(c => (c.args[0] as string).includes('git remote add origin'));
+            expect(addOrigin!.args[0]).to.contain('git@github.com:myuser/glsp-client.git');
+        });
+
+        it('should use https URL when protocol is https', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({ origin: 'https://github.com/eclipse-glsp/glsp-client.git' });
+
+            await configureForkRemote('glsp-client', repoDir, 'myuser', 'https');
+
+            const addOrigin = execStub.getCalls().find(c => (c.args[0] as string).includes('git remote add origin'));
+            expect(addOrigin!.args[0]).to.contain('https://github.com/myuser/glsp-client.git');
+        });
+
+        it('should pass correct cwd for git commands', async () => {
+            const repoDir = createRepoDir('glsp-server-node');
+            getRemotesStub.returns({ origin: 'https://github.com/eclipse-glsp/glsp-server-node.git' });
+
+            await configureForkRemote('glsp-server-node', repoDir, 'myuser', 'ssh');
+
+            for (const call of execStub.getCalls()) {
+                expect(call.args[1]).to.have.property('cwd', repoDir);
+            }
+        });
+
+        it('should call ensureFork for rename-origin', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({ origin: 'https://github.com/eclipse-glsp/glsp-client.git' });
+
+            await configureForkRemote('glsp-client', repoDir, 'testuser', 'ssh');
+
+            expect(ensureForkStub.calledOnceWith('testuser', 'glsp-client')).to.be.true;
+        });
+
+        it('should call ensureFork for set-origin', async () => {
+            const repoDir = createRepoDir('glsp-client');
+            getRemotesStub.returns({
+                origin: 'https://github.com/eclipse-glsp/glsp-client.git',
+                upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
+            });
+
+            await configureForkRemote('glsp-client', repoDir, 'testuser', 'https');
+
+            expect(ensureForkStub.calledOnceWith('testuser', 'glsp-client')).to.be.true;
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/fork.ts
+++ b/dev-packages/cli/src/commands/repo/fork.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Command, Option } from 'commander';
+import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, exec, resolveDefaultProtocol } from '../../util';
+import { analyzeForkRemotes, ensureFork, getRemoteUrl, getRemotes } from './common/fork-utils';
+import { configureRepoEnv, formatError, resolveTargetRepos } from './common/utils';
+
+export async function configureForkRemote(repo: GLSPRepo, repoDir: string, user: string, protocol: 'ssh' | 'https' | 'gh'): Promise<void> {
+    const remotes = getRemotes(repoDir);
+    const action = analyzeForkRemotes(remotes, user, repo);
+
+    switch (action) {
+        case 'already-configured':
+            LOGGER.info(`${repo}: fork remotes already configured, skipping`);
+            break;
+
+        case 'rename-origin': {
+            await ensureFork(user, repo);
+            LOGGER.info(`${repo}: renaming origin → upstream, adding fork as origin`);
+            exec('git remote rename origin upstream', { cwd: repoDir });
+            const forkUrl = getRemoteUrl(protocol, user, repo);
+            exec(`git remote add origin ${forkUrl}`, { cwd: repoDir });
+            break;
+        }
+
+        case 'set-origin': {
+            await ensureFork(user, repo);
+            LOGGER.info(`${repo}: setting origin to fork`);
+            const forkUrl = getRemoteUrl(protocol, user, repo);
+            exec(`git remote set-url origin ${forkUrl}`, { cwd: repoDir });
+            break;
+        }
+
+        case 'unexpected':
+            LOGGER.warn(
+                `${repo}: unexpected remote configuration ` +
+                    `(origin=${remotes.origin ?? 'none'}, upstream=${remotes.upstream ?? 'none'}), skipping`
+            );
+            break;
+    }
+}
+
+export const ForkCommand = baseCommand()
+    .name('fork')
+    .description('Add fork remotes to already-cloned repositories')
+    .argument('<user>', 'GitHub username for the fork')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .addOption(new Option('-p, --protocol <protocol>', 'Git clone protocol (default: gh|https)').choices(['ssh', 'https', 'gh']))
+    .addOption(new Option('-r, --repo <name...>', 'Fork only these repos'))
+    .addOption(new Option('--preset <name>', 'Fork repos from a preset').choices(PRESET_NAMES))
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (user: string, _cmdOptions: any, thisCmd: Command) => {
+        const cli = thisCmd.opts<{ dir?: string; protocol?: string; verbose: boolean; repo?: string[]; preset?: string }>();
+        configureRepoEnv(cli);
+
+        const { dir, repos } = resolveTargetRepos(cli);
+        const protocol = (cli.protocol as 'ssh' | 'https' | 'gh') ?? resolveDefaultProtocol();
+
+        let failures = 0;
+        for (const repo of repos) {
+            const repoDir = path.resolve(dir, repo);
+
+            if (!fs.existsSync(repoDir)) {
+                LOGGER.warn(`${repo}: not cloned at ${repoDir}, skipping`);
+                continue;
+            }
+
+            try {
+                await configureForkRemote(repo, repoDir, user, protocol);
+            } catch (error) {
+                failures++;
+                LOGGER.error(`${repo}: ${formatError(error)}`);
+            }
+        }
+
+        if (failures > 0) {
+            process.exitCode = 1;
+        }
+    });

--- a/dev-packages/cli/src/commands/repo/fork.ts
+++ b/dev-packages/cli/src/commands/repo/fork.ts
@@ -21,6 +21,14 @@ import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, exec, resolveDefaultProtoc
 import { analyzeForkRemotes, ensureFork, getRemoteUrl, getRemotes } from './common/fork-utils';
 import { configureRepoEnv, formatError, resolveTargetRepos } from './common/utils';
 
+interface ForkCliOptions {
+    dir?: string;
+    protocol?: 'ssh' | 'https' | 'gh';
+    verbose: boolean;
+    repo?: string[];
+    preset?: string;
+}
+
 export async function configureForkRemote(repo: GLSPRepo, repoDir: string, user: string, protocol: 'ssh' | 'https' | 'gh'): Promise<void> {
     const remotes = getRemotes(repoDir);
     const action = analyzeForkRemotes(remotes, user, repo);
@@ -65,12 +73,12 @@ export const ForkCommand = baseCommand()
     .addOption(new Option('-r, --repo <name...>', 'Fork only these repos'))
     .addOption(new Option('--preset <name>', 'Fork repos from a preset').choices(PRESET_NAMES))
     .option('-v, --verbose', 'Verbose output', false)
-    .action(async (user: string, _cmdOptions: any, thisCmd: Command) => {
-        const cli = thisCmd.opts<{ dir?: string; protocol?: string; verbose: boolean; repo?: string[]; preset?: string }>();
+    .action(async (user: string, _cmdOptions: unknown, thisCmd: Command) => {
+        const cli = thisCmd.opts<ForkCliOptions>();
         configureRepoEnv(cli);
 
         const { dir, repos } = resolveTargetRepos(cli);
-        const protocol = (cli.protocol as 'ssh' | 'https' | 'gh') ?? resolveDefaultProtocol();
+        const protocol = cli.protocol ?? resolveDefaultProtocol();
 
         let failures = 0;
         for (const repo of repos) {

--- a/dev-packages/cli/src/commands/repo/link.spec.ts
+++ b/dev-packages/cli/src/commands/repo/link.spec.ts
@@ -1,0 +1,369 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { GLSPRepo, PackageHelper } from '../../util';
+import * as packageUtil from '../../util/package-util';
+import * as processUtil from '../../util/process-util';
+import { cleanupTempDir, createTempDir } from '../../../tests/helpers/test-helper';
+import {
+    SINGLETON_DEPS,
+    LinkActionOptions,
+    filterLinkableRepos,
+    getGLSPWorkspacePackages,
+    getRegisteredPackages,
+    registerPackages,
+    registerSingletons,
+    consumePackages,
+    consumeSingletons,
+    runLink,
+    runUnlink
+} from './link';
+
+function mockPkg(name: string, location: string, deps: Record<string, string> = {}, devDeps: Record<string, string> = {}): PackageHelper {
+    return {
+        name,
+        location,
+        filePath: path.join(location, 'package.json'),
+        content: { name, version: '1.0.0', dependencies: deps, devDependencies: devDeps }
+    } as unknown as PackageHelper;
+}
+
+describe('link-action', () => {
+    const sandbox = sinon.createSandbox();
+    let tempDir: string;
+    let execStub: sinon.SinonStub;
+    let execAsyncStub: sinon.SinonStub;
+    let workspaceStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        execStub = sandbox.stub(processUtil, 'exec').returns('');
+        execAsyncStub = sandbox.stub(processUtil, 'execAsync').resolves('');
+        workspaceStub = sandbox.stub(packageUtil, 'getYarnWorkspacePackages');
+        workspaceStub.returns([]);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        cleanupTempDir(tempDir);
+    });
+
+    function createRepoDirs(...names: string[]): void {
+        for (const name of names) {
+            fs.mkdirSync(path.join(tempDir, name), { recursive: true });
+        }
+    }
+
+    function createNodeModules(repo: string, ...deps: string[]): void {
+        for (const dep of deps) {
+            fs.mkdirSync(path.join(tempDir, repo, 'node_modules', dep), { recursive: true });
+        }
+    }
+
+    function makeOptions(overrides: Partial<LinkActionOptions> = {}): LinkActionOptions {
+        return { dir: tempDir, verbose: false, failFast: true, ...overrides };
+    }
+
+    function setupWorkspaceStub(): void {
+        const clientPkg = mockPkg('@eclipse-glsp/client', path.join(tempDir, 'glsp-client/packages/client'));
+        const protocolPkg = mockPkg('@eclipse-glsp/protocol', path.join(tempDir, 'glsp-client/packages/protocol'));
+        const serverPkg = mockPkg('@eclipse-glsp/server', path.join(tempDir, 'glsp-server-node/packages/server'), {
+            '@eclipse-glsp/protocol': '^1.0.0'
+        });
+        workspaceStub.callsFake((rootPath: string, includeRoot?: boolean) => {
+            const repoName = path.basename(rootPath);
+            let packages: PackageHelper[];
+            if (repoName === 'glsp-client') {
+                packages = [clientPkg, protocolPkg];
+            } else if (repoName === 'glsp-server-node') {
+                packages = [serverPkg];
+            } else {
+                packages = [];
+            }
+            return includeRoot ? [mockPkg(repoName, rootPath), ...packages] : packages;
+        });
+    }
+
+    describe('filterLinkableRepos', () => {
+        it('should keep linkable npm repos', () => {
+            const result = filterLinkableRepos(['glsp-client', 'glsp-server-node', 'glsp-theia-integration'] as GLSPRepo[]);
+            expect(result).to.deep.equal(['glsp-client', 'glsp-server-node', 'glsp-theia-integration']);
+        });
+
+        it('should exclude non-linkable repos', () => {
+            const result = filterLinkableRepos(['glsp-client', 'glsp-server', 'glsp-eclipse-integration', 'glsp-playwright'] as GLSPRepo[]);
+            expect(result).to.deep.equal(['glsp-client']);
+        });
+    });
+
+    describe('getRegisteredPackages', () => {
+        it('should return scoped packages from the link directory', () => {
+            const linkDir = path.join(tempDir, '.yarn-link');
+            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'client'), { recursive: true });
+            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'protocol'), { recursive: true });
+            const result = getRegisteredPackages(linkDir);
+            expect(result).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
+        });
+
+        it('should return empty array when link directory does not exist', () => {
+            const result = getRegisteredPackages(path.join(tempDir, 'nonexistent'));
+            expect(result).to.deep.equal([]);
+        });
+
+        it('should ignore non-scoped entries', () => {
+            const linkDir = path.join(tempDir, '.yarn-link');
+            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'client'), { recursive: true });
+            fs.writeFileSync(path.join(linkDir, 'sprotty'), '');
+            const result = getRegisteredPackages(linkDir);
+            expect(result).to.deep.equal(['@eclipse-glsp/client']);
+        });
+    });
+
+    describe('registerPackages', () => {
+        it('should run yarn link for each @eclipse-glsp workspace package and return names', () => {
+            const repoDir = path.join(tempDir, 'glsp-client');
+            const linkDir = path.join(tempDir, '.yarn-link');
+            workspaceStub
+                .withArgs(repoDir)
+                .returns([
+                    mockPkg('@eclipse-glsp/client', path.join(repoDir, 'packages/client')),
+                    mockPkg('@eclipse-glsp/protocol', path.join(repoDir, 'packages/protocol'))
+                ]);
+            const registered = registerPackages(repoDir, linkDir);
+            expect(registered).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
+            expect(execStub.callCount).to.equal(2);
+            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir}`);
+            expect(execStub.firstCall.args[1].cwd).to.equal(path.join(repoDir, 'packages/client'));
+            expect(execStub.secondCall.args[1].cwd).to.equal(path.join(repoDir, 'packages/protocol'));
+        });
+    });
+
+    describe('registerSingletons', () => {
+        it('should run yarn link for each singleton in node_modules', () => {
+            const clientDir = path.join(tempDir, 'glsp-client');
+            const linkDir = path.join(tempDir, '.yarn-link');
+            registerSingletons(clientDir, linkDir);
+            expect(execStub.callCount).to.equal(SINGLETON_DEPS.length);
+            for (let i = 0; i < SINGLETON_DEPS.length; i++) {
+                expect(execStub.getCall(i).args[0]).to.equal(`yarn link --link-folder ${linkDir}`);
+                expect(execStub.getCall(i).args[1].cwd).to.equal(path.join(clientDir, 'node_modules', SINGLETON_DEPS[i]));
+            }
+        });
+    });
+
+    describe('consumePackages', () => {
+        it('should link all registered packages into the repo', () => {
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            const linkDir = path.join(tempDir, '.yarn-link');
+            consumePackages(repoDir, linkDir, ['@eclipse-glsp/protocol', '@eclipse-glsp/client']);
+            expect(execStub.calledOnce).to.be.true;
+            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir} @eclipse-glsp/protocol @eclipse-glsp/client`);
+            expect(execStub.firstCall.args[1].cwd).to.equal(repoDir);
+        });
+
+        it('should not call exec when registeredPackages is empty', () => {
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            const linkDir = path.join(tempDir, '.yarn-link');
+            consumePackages(repoDir, linkDir, []);
+            expect(execStub.called).to.be.false;
+        });
+    });
+
+    describe('consumeSingletons', () => {
+        it('should link all singleton deps', () => {
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            const linkDir = path.join(tempDir, '.yarn-link');
+            consumeSingletons(repoDir, linkDir);
+            expect(execStub.calledOnce).to.be.true;
+            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`);
+            expect(execStub.firstCall.args[1].cwd).to.equal(repoDir);
+        });
+    });
+
+    describe('getGLSPWorkspacePackages', () => {
+        it('should filter to @eclipse-glsp scoped packages', () => {
+            const repoDir = path.join(tempDir, 'glsp-client');
+            workspaceStub
+                .withArgs(repoDir)
+                .returns([
+                    mockPkg('@eclipse-glsp/client', path.join(repoDir, 'packages/client')),
+                    mockPkg('@eclipse-glsp/protocol', path.join(repoDir, 'packages/protocol')),
+                    mockPkg('some-other-pkg', path.join(repoDir, 'packages/other'))
+                ]);
+            const result = getGLSPWorkspacePackages(repoDir);
+            expect(result).to.have.length(2);
+            expect(result.map(p => p.name)).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
+        });
+    });
+
+    describe('runLink', () => {
+        it('should register, consume, and reinstall in build order', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            createNodeModules('glsp-client', ...SINGLETON_DEPS);
+            setupWorkspaceStub();
+
+            await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
+
+            const linkDir = path.join(tempDir, '.yarn-link');
+
+            const clientRegCalls = execStub
+                .getCalls()
+                .filter(
+                    (c: sinon.SinonSpyCall) =>
+                        c.args[0] === `yarn link --link-folder ${linkDir}` && (c.args[1]?.cwd as string)?.includes('glsp-client/packages')
+                );
+            expect(clientRegCalls).to.have.length(2);
+
+            const singletonRegCalls = execStub
+                .getCalls()
+                .filter(
+                    (c: sinon.SinonSpyCall) =>
+                        c.args[0] === `yarn link --link-folder ${linkDir}` &&
+                        (c.args[1]?.cwd as string)?.includes('glsp-client/node_modules')
+                );
+            expect(singletonRegCalls).to.have.length(SINGLETON_DEPS.length);
+
+            const clientConsumeCall = execStub
+                .getCalls()
+                .find(
+                    (c: sinon.SinonSpyCall) =>
+                        (c.args[0] as string).includes('@eclipse-glsp/client') && c.args[1]?.cwd === path.join(tempDir, 'glsp-client')
+                );
+            expect(clientConsumeCall).to.be.undefined;
+
+            const consumeCall = execStub
+                .getCalls()
+                .find(
+                    (c: sinon.SinonSpyCall) =>
+                        (c.args[0] as string).includes('@eclipse-glsp/client') &&
+                        (c.args[0] as string).includes('@eclipse-glsp/protocol') &&
+                        (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
+                );
+            expect(consumeCall).to.not.be.undefined;
+
+            const singletonConsumeCall = execStub
+                .getCalls()
+                .find(
+                    (c: sinon.SinonSpyCall) =>
+                        (c.args[0] as string).includes(SINGLETON_DEPS.join(' ')) && (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
+                );
+            expect(singletonConsumeCall).to.not.be.undefined;
+
+            expect(execAsyncStub.callCount).to.equal(3);
+            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
+            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn install --force');
+            expect(execAsyncStub.thirdCall.args[0]).to.equal('yarn install --force');
+        });
+
+        it('should run yarn install before registering singletons for glsp-client', async () => {
+            createRepoDirs('glsp-client');
+            setupWorkspaceStub();
+
+            await runLink(['glsp-client'] as GLSPRepo[], makeOptions());
+
+            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
+            expect(execAsyncStub.firstCall.args[1].cwd).to.equal(path.join(tempDir, 'glsp-client'));
+        });
+
+        it('should stop on first failure when failFast is true', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            workspaceStub.returns([]);
+            execStub.throws(new Error('link failed'));
+            try {
+                await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
+                expect.fail('should have thrown');
+            } catch (error) {
+                expect((error as Error).message).to.contain('failed to link');
+            }
+        });
+
+        it('should continue on failure when failFast is false', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            createNodeModules('glsp-client', ...SINGLETON_DEPS);
+            setupWorkspaceStub();
+            execStub.onFirstCall().throws(new Error('link failed'));
+            execStub.returns('');
+
+            try {
+                await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: false }));
+                expect.fail('should have thrown');
+            } catch (error) {
+                expect((error as Error).message).to.contain('failed to link');
+            }
+            expect(execAsyncStub.called).to.be.true;
+        });
+
+        it('should skip non-linkable repos', async () => {
+            createRepoDirs('glsp-server');
+            await runLink(['glsp-server'] as GLSPRepo[], makeOptions());
+            expect(execStub.called).to.be.false;
+            expect(execAsyncStub.called).to.be.false;
+        });
+    });
+
+    describe('runUnlink', () => {
+        function createLinkDir(...packages: string[]): void {
+            for (const pkg of packages) {
+                fs.mkdirSync(path.join(tempDir, '.yarn-link', pkg), { recursive: true });
+            }
+        }
+
+        it('should unlink repos in reverse build order', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            createNodeModules('glsp-client', ...SINGLETON_DEPS);
+            createLinkDir('@eclipse-glsp/client', '@eclipse-glsp/protocol');
+            setupWorkspaceStub();
+
+            await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
+
+            const linkDir = path.join(tempDir, '.yarn-link');
+
+            const serverUnlinks = execStub
+                .getCalls()
+                .filter(
+                    (c: sinon.SinonSpyCall) =>
+                        (c.args[0] as string).startsWith('yarn unlink') && (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
+                );
+            expect(serverUnlinks.length).to.be.greaterThan(0);
+
+            const clientUnregCalls = execStub
+                .getCalls()
+                .filter(
+                    (c: sinon.SinonSpyCall) =>
+                        c.args[0] === `yarn unlink --link-folder ${linkDir}` && (c.args[1]?.cwd as string)?.includes('glsp-client/packages')
+                );
+            expect(clientUnregCalls).to.have.length(2);
+
+            expect(execAsyncStub.callCount).to.equal(2);
+        });
+
+        it('should stop on first failure when failFast is true', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            setupWorkspaceStub();
+            execStub.throws(new Error('unlink failed'));
+            try {
+                await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
+                expect.fail('should have thrown');
+            } catch (error) {
+                expect((error as Error).message).to.contain('failed to unlink');
+            }
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/link.ts
+++ b/dev-packages/cli/src/commands/repo/link.ts
@@ -1,0 +1,280 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Command, Option } from 'commander';
+import { GLSPRepo, LOGGER, PRESET_NAMES, PackageHelper, baseCommand, exec, execAsync, getYarnWorkspacePackages } from '../../util';
+import { configureRepoEnv, formatError, getBuildOrder, isLeafRepo, resolveTargetRepos, validateReposExist } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export const SINGLETON_DEPS = ['sprotty', 'sprotty-protocol', 'vscode-jsonrpc', 'inversify'] as const;
+
+const YARN_EXEC_OPTS = { silent: false, env: { FORCE_COLOR: '1' } } as const;
+
+const LINKABLE_REPOS: readonly GLSPRepo[] = [
+    'glsp',
+    'glsp-client',
+    'glsp-server-node',
+    'glsp-theia-integration',
+    'glsp-vscode-integration'
+];
+
+export interface LinkActionOptions {
+    dir: string;
+    verbose: boolean;
+    failFast: boolean;
+}
+
+export function filterLinkableRepos(repos: GLSPRepo[]): GLSPRepo[] {
+    return repos.filter(r => (LINKABLE_REPOS as readonly string[]).includes(r));
+}
+
+export function getGLSPWorkspacePackages(repoDir: string): PackageHelper[] {
+    const packages = getYarnWorkspacePackages(repoDir);
+    return packages.filter(pkg => pkg.name.startsWith('@eclipse-glsp'));
+}
+
+export function getRegisteredPackages(linkDir: string): string[] {
+    const packages: string[] = [];
+    if (!fs.existsSync(linkDir)) {
+        return packages;
+    }
+    for (const entry of fs.readdirSync(linkDir)) {
+        const entryPath = path.join(linkDir, entry);
+        if (entry.startsWith('@') && fs.statSync(entryPath).isDirectory()) {
+            for (const sub of fs.readdirSync(entryPath)) {
+                packages.push(`${entry}/${sub}`);
+            }
+        }
+    }
+    return packages;
+}
+
+export function registerPackages(repoDir: string, linkDir: string): string[] {
+    const packages = getGLSPWorkspacePackages(repoDir);
+    const registered: string[] = [];
+    for (const pkg of packages) {
+        LOGGER.debug(`Registering ${pkg.name}`);
+        exec(`yarn link --link-folder ${linkDir}`, { cwd: pkg.location, ...YARN_EXEC_OPTS });
+        registered.push(pkg.name);
+    }
+    return registered;
+}
+
+export function registerSingletons(clientDir: string, linkDir: string): void {
+    for (const dep of SINGLETON_DEPS) {
+        const depDir = path.join(clientDir, 'node_modules', dep);
+        LOGGER.debug(`Registering singleton ${dep}`);
+        exec(`yarn link --link-folder ${linkDir}`, { cwd: depDir, ...YARN_EXEC_OPTS });
+    }
+}
+
+export function consumePackages(repoDir: string, linkDir: string, registeredPackages: string[]): void {
+    if (registeredPackages.length === 0) {
+        return;
+    }
+    LOGGER.debug(`Linking ${registeredPackages.join(', ')} into ${path.basename(repoDir)}`);
+    exec(`yarn link --link-folder ${linkDir} ${registeredPackages.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+}
+
+export function consumeSingletons(repoDir: string, linkDir: string): void {
+    LOGGER.debug(`Linking singletons into ${path.basename(repoDir)}`);
+    exec(`yarn link --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+}
+
+export async function runLink(repos: GLSPRepo[], options: LinkActionOptions): Promise<void> {
+    const linkable = filterLinkableRepos(repos);
+    if (linkable.length === 0) {
+        LOGGER.warn('No linkable repositories found.');
+        return;
+    }
+    if (!linkable.includes('glsp-client')) {
+        LOGGER.warn('glsp-client is not in the configured repos. Linking without glsp-client may not produce useful results.');
+    }
+
+    validateReposExist(linkable, options.dir);
+    const linkDir = path.resolve(options.dir, '.yarn-link');
+    const ordered = getBuildOrder(linkable);
+    const registeredPackages: string[] = [];
+    let failures = 0;
+
+    LOGGER.label('Linking repositories');
+
+    for (let i = 0; i < ordered.length; i++) {
+        const repo = ordered[i];
+        try {
+            if (i > 0) {
+                LOGGER.newLine();
+            }
+            const repoDir = path.resolve(options.dir, repo);
+            LOGGER.info(`Linking ${repo}...`);
+
+            const packagesFromPriorRepos = [...registeredPackages];
+
+            if (!isLeafRepo(repo)) {
+                const registered = registerPackages(repoDir, linkDir);
+                registeredPackages.push(...registered);
+            }
+
+            if (repo === 'glsp-client') {
+                await execAsync('yarn install', { cwd: repoDir, ...YARN_EXEC_OPTS });
+                registerSingletons(repoDir, linkDir);
+            }
+
+            await execAsync('yarn install --force', { cwd: repoDir, ...YARN_EXEC_OPTS });
+
+            consumePackages(repoDir, linkDir, packagesFromPriorRepos);
+
+            if (repo !== 'glsp-client' && linkable.includes('glsp-client')) {
+                consumeSingletons(repoDir, linkDir);
+            }
+
+            LOGGER.info(`Successfully linked ${repo}`);
+        } catch (error) {
+            failures++;
+            LOGGER.error(`Linking ${repo} failed: ${formatError(error)}`);
+            if (options.failFast) {
+                break;
+            }
+        }
+    }
+
+    if (failures > 0) {
+        throw new Error(`${failures} repo(s) failed to link.`);
+    }
+
+    LOGGER.info('Linking complete.');
+}
+
+export async function runUnlink(repos: GLSPRepo[], options: LinkActionOptions): Promise<void> {
+    const linkable = filterLinkableRepos(repos);
+    if (linkable.length === 0) {
+        LOGGER.warn('No linkable repositories found.');
+        return;
+    }
+
+    validateReposExist(linkable, options.dir);
+    const linkDir = path.resolve(options.dir, '.yarn-link');
+    const ordered = getBuildOrder(linkable);
+    const reversed = [...ordered].reverse();
+    let failures = 0;
+
+    LOGGER.label('Unlinking repositories');
+
+    for (let i = 0; i < reversed.length; i++) {
+        const repo = reversed[i];
+        try {
+            if (i > 0) {
+                LOGGER.newLine();
+            }
+            const repoDir = path.resolve(options.dir, repo);
+            LOGGER.info(`Unlinking ${repo}...`);
+
+            if (repo !== 'glsp-client' && linkable.includes('glsp-client')) {
+                exec(`yarn unlink --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+            }
+
+            const allLinkedPackages = getRegisteredPackages(linkDir);
+            if (allLinkedPackages.length > 0) {
+                exec(`yarn unlink --link-folder ${linkDir} ${allLinkedPackages.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+            }
+
+            if (repo === 'glsp-client') {
+                for (const dep of SINGLETON_DEPS) {
+                    const depDir = path.join(repoDir, 'node_modules', dep);
+                    if (fs.existsSync(depDir)) {
+                        exec(`yarn unlink --link-folder ${linkDir}`, { cwd: depDir, ...YARN_EXEC_OPTS });
+                    }
+                }
+            }
+
+            if (!isLeafRepo(repo)) {
+                const packages = getGLSPWorkspacePackages(repoDir);
+                for (const pkg of packages) {
+                    exec(`yarn unlink --link-folder ${linkDir}`, { cwd: pkg.location, ...YARN_EXEC_OPTS });
+                }
+            }
+
+            await execAsync('yarn install --force', { cwd: repoDir, ...YARN_EXEC_OPTS });
+
+            LOGGER.info(`Successfully unlinked ${repo}`);
+        } catch (error) {
+            failures++;
+            LOGGER.error(`Unlinking ${repo} failed: ${formatError(error)}`);
+            if (options.failFast) {
+                break;
+            }
+        }
+    }
+
+    if (failures > 0) {
+        throw new Error(`${failures} repo(s) failed to unlink.`);
+    }
+
+    LOGGER.info('Unlinking complete.');
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface LinkCliOptions {
+    dir?: string;
+    verbose: boolean;
+    repo?: string[];
+    preset?: string;
+    failFast: boolean;
+}
+
+export const LinkCommand = baseCommand()
+    .name('link')
+    .description('Interlink repositories via yarn link')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .addOption(new Option('-r, --repo <name...>', 'Link only these repos'))
+    .addOption(new Option('--preset <name>', 'Link repos from a preset').choices(PRESET_NAMES))
+    .option('--no-fail-fast', 'Continue after a failure')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: LinkCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<LinkCliOptions>();
+        configureRepoEnv(cli);
+        const { dir, repos } = resolveTargetRepos(cli);
+
+        try {
+            await runLink(repos, { dir, verbose: cli.verbose, failFast: cli.failFast });
+        } catch {
+            process.exitCode = 1;
+        }
+    });
+
+export const UnlinkCommand = baseCommand()
+    .name('unlink')
+    .description('Remove yarn links between repositories')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .addOption(new Option('-r, --repo <name...>', 'Unlink only these repos'))
+    .addOption(new Option('--preset <name>', 'Unlink repos from a preset').choices(PRESET_NAMES))
+    .option('--no-fail-fast', 'Continue after a failure')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: LinkCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<LinkCliOptions>();
+        configureRepoEnv(cli);
+        const { dir, repos } = resolveTargetRepos(cli);
+
+        try {
+            await runUnlink(repos, { dir, verbose: cli.verbose, failFast: cli.failFast });
+        } catch {
+            process.exitCode = 1;
+        }
+    });

--- a/dev-packages/cli/src/commands/repo/log.ts
+++ b/dev-packages/cli/src/commands/repo/log.ts
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as path from 'path';
+import { Command, Option } from 'commander';
+import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, exec } from '../../util';
+import { configureRepoEnv, resolveTargetRepos, resolveWorkspaceDir, validateReposExist } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export function logSingleRepo(repoDir: string): void {
+    exec('git --no-pager log -1', { cwd: repoDir, silent: false });
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+export function createScopedLogCommand(repo: GLSPRepo): Command {
+    return baseCommand()
+        .name('log')
+        .description(`Print the last commit for ${repo}`)
+        .option('-d, --dir <path>', 'Target directory where repos are cloned')
+        .option('-v, --verbose', 'Verbose output', false)
+        .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+            const cli = thisCmd.opts<{ dir?: string; verbose: boolean }>();
+            configureRepoEnv(cli);
+            const dir = resolveWorkspaceDir(cli.dir);
+            const repoDir = path.resolve(dir, repo);
+            logSingleRepo(repoDir);
+        });
+}
+
+export const LogCommand = baseCommand()
+    .name('log')
+    .description('Print the last commit for all discovered repositories')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .addOption(new Option('-r, --repo <name...>', 'Log only these repos'))
+    .addOption(new Option('--preset <name>', 'Log repos from a preset').choices(PRESET_NAMES))
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+        const cli = thisCmd.opts<{ dir?: string; verbose: boolean; repo?: string[]; preset?: string }>();
+        configureRepoEnv(cli);
+
+        const { dir, repos } = resolveTargetRepos(cli);
+        validateReposExist(repos, dir);
+
+        for (let i = 0; i < repos.length; i++) {
+            const repo = repos[i];
+            if (i > 0) {
+                LOGGER.newLine();
+            }
+            const repoDir = path.resolve(dir, repo);
+            LOGGER.label(repo);
+            logSingleRepo(repoDir);
+        }
+    });

--- a/dev-packages/cli/src/commands/repo/open.ts
+++ b/dev-packages/cli/src/commands/repo/open.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from 'commander';
+import { LOGGER, baseCommand } from '../../util';
+import { THEIA_URL, configureRepoEnv } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export async function openTarget(target: string): Promise<void> {
+    LOGGER.info(`Opening ${target}...`);
+    const { default: open } = await import('open');
+    await open(target);
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface TheiaOpenCliOptions {
+    verbose: boolean;
+}
+
+export const TheiaOpenCommand = baseCommand()
+    .name('open')
+    .description('Open the Theia application in the browser for glsp-theia-integration')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: TheiaOpenCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<TheiaOpenCliOptions>();
+        configureRepoEnv(cli);
+
+        await openTarget(THEIA_URL);
+    });

--- a/dev-packages/cli/src/commands/repo/pwd.ts
+++ b/dev-packages/cli/src/commands/repo/pwd.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as path from 'path';
+import { Command } from 'commander';
+import { GLSPRepo, LOGGER, baseCommand } from '../../util';
+import { configureRepoEnv, discoverRepos, resolveWorkspaceDir } from './common/utils';
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+export function createScopedPwdCommand(repo: GLSPRepo): Command {
+    return baseCommand()
+        .name('pwd')
+        .description(`Print the resolved path for ${repo}`)
+        .option('-d, --dir <path>', 'Target directory where repos are cloned')
+        .option('-v, --verbose', 'Verbose output', false)
+        .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+            const cli = thisCmd.opts<{ dir?: string; verbose: boolean }>();
+            configureRepoEnv(cli);
+            const dir = resolveWorkspaceDir(cli.dir);
+            const repoPath = path.resolve(dir, repo);
+            process.stdout.write(repoPath + '\n');
+        });
+}
+
+export const PwdCommand = baseCommand()
+    .name('pwd')
+    .description('Print resolved paths for all discovered repositories')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('--raw', 'Print repo<tab>path per line, no color', false)
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+        const cli = thisCmd.opts<{ dir?: string; verbose: boolean; raw: boolean }>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repos = discoverRepos(dir);
+
+        if (repos.length === 0) {
+            throw new Error(`No GLSP repositories found in '${dir}'. Clone repositories first with 'glsp repo clone'.`);
+        }
+
+        if (cli.raw) {
+            for (const repo of repos) {
+                const repoPath = path.resolve(dir, repo);
+                process.stdout.write(`${repo}\t${repoPath}\n`);
+            }
+            return;
+        }
+
+        const maxLen = Math.max(...repos.map(r => r.length));
+        for (const repo of repos) {
+            const repoPath = path.resolve(dir, repo);
+            const padded = repo.padEnd(maxLen + 2);
+            LOGGER.info(`${padded}${repoPath}`);
+        }
+    });

--- a/dev-packages/cli/src/commands/repo/repo.ts
+++ b/dev-packages/cli/src/commands/repo/repo.ts
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { GLSPRepo, baseCommand } from '../../util';
+import { BuildCommand } from './build';
+import { CloneCommand } from './clone';
+import { ForkCommand } from './fork';
+import { LinkCommand, UnlinkCommand } from './link';
+import { LogCommand } from './log';
+import { PwdCommand } from './pwd';
+import { createSubrepoCommand } from './subrepos';
+import { WorkspaceCommand } from './workspace';
+
+export const RepoCommand = baseCommand()
+    .name('repo')
+    .description('Multi-repository management for GLSP projects')
+    .addCommand(CloneCommand)
+    .addCommand(ForkCommand)
+    .addCommand(BuildCommand)
+    .addCommand(LinkCommand)
+    .addCommand(UnlinkCommand)
+    .addCommand(PwdCommand)
+    .addCommand(LogCommand)
+    .addCommand(WorkspaceCommand);
+
+for (const repo of GLSPRepo.choices) {
+    RepoCommand.addCommand(createSubrepoCommand(repo));
+}

--- a/dev-packages/cli/src/commands/repo/start.spec.ts
+++ b/dev-packages/cli/src/commands/repo/start.spec.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cleanupTempDir, createTempDir } from '../../../tests/helpers/test-helper';
+import { JAR_TARGET_DIR, discoverJar } from './start';
+
+describe('start-action', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    describe('discoverJar', () => {
+        function createTargetDir(): string {
+            const targetDir = path.join(tempDir, JAR_TARGET_DIR);
+            fs.mkdirSync(targetDir, { recursive: true });
+            return targetDir;
+        }
+
+        function createJar(targetDir: string, name: string, mtimeMs?: number): string {
+            const jarPath = path.join(targetDir, name);
+            fs.writeFileSync(jarPath, 'fake-jar');
+            if (mtimeMs !== undefined) {
+                const atime = new Date(mtimeMs);
+                const mtime = new Date(mtimeMs);
+                fs.utimesSync(jarPath, atime, mtime);
+            }
+            return jarPath;
+        }
+
+        it('should find a single *-glsp.jar', () => {
+            const targetDir = createTargetDir();
+            createJar(targetDir, 'org.eclipse.glsp.example.workflow-2.0.0-glsp.jar');
+            const result = discoverJar(tempDir);
+            expect(result).to.contain('org.eclipse.glsp.example.workflow-2.0.0-glsp.jar');
+        });
+
+        it('should pick the newest JAR by mtime when multiple exist', () => {
+            const targetDir = createTargetDir();
+            createJar(targetDir, 'old-glsp.jar', 1000000);
+            createJar(targetDir, 'new-glsp.jar', 2000000);
+            const result = discoverJar(tempDir);
+            expect(result).to.contain('new-glsp.jar');
+        });
+
+        it('should throw when no JAR is found', () => {
+            createTargetDir();
+            expect(() => discoverJar(tempDir)).to.throw(/No \*-glsp\.jar found/);
+        });
+
+        it('should throw with helpful message when target directory does not exist', () => {
+            expect(() => discoverJar(tempDir)).to.throw(/glsp repo server build/);
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/start.ts
+++ b/dev-packages/cli/src/commands/repo/start.ts
@@ -1,0 +1,121 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as path from 'path';
+import { Command } from 'commander';
+import { LOGGER, baseCommand, execForeground } from '../../util';
+import { configureRepoEnv, discoverNewestFile, resolveWorkspaceDir } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export const JAR_TARGET_DIR = 'examples/org.eclipse.glsp.example.workflow/target';
+const JAR_PATTERN = '*-glsp.jar';
+
+export function discoverJar(repoDir: string): string {
+    const targetDir = path.resolve(repoDir, JAR_TARGET_DIR);
+    return discoverNewestFile(JAR_PATTERN, targetDir, `No *-glsp.jar found in ${targetDir}. Run \`glsp repo server build\` first.`);
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface TheiaStartCliOptions {
+    dir?: string;
+    electron: boolean;
+    debug: boolean;
+    verbose: boolean;
+}
+
+export const TheiaStartCommand = baseCommand()
+    .name('start')
+    .description('Start the Theia application for glsp-theia-integration')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('--electron', 'Start electron variant instead of browser', false)
+    .option('--debug', 'Connect to external GLSP server for debugging', false)
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: TheiaStartCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<TheiaStartCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-theia-integration');
+        const target = cli.electron ? 'electron' : 'browser';
+        const script = cli.debug ? 'start:debug' : 'start';
+        await execForeground(`yarn ${target} ${script}`, { cwd: repoDir, verbose: cli.verbose });
+    });
+
+interface ClientStartCliOptions {
+    dir?: string;
+    browser: boolean;
+    verbose: boolean;
+}
+
+export const ClientStartCommand = baseCommand()
+    .name('start')
+    .description('Start the standalone example for glsp-client')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('--browser', 'Run in browser-only mode with WebWorker server', false)
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: ClientStartCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<ClientStartCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-client');
+        const script = cli.browser ? 'dev:browser' : 'dev';
+        await execForeground(`yarn ${script}`, { cwd: repoDir, verbose: cli.verbose });
+    });
+
+export const ServerStartCommand = baseCommand()
+    .name('start')
+    .description('Start the glsp-server Java GLSP server')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('--socket', 'Use socket connection instead of websocket', false)
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: ServerNodeStartCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<ServerNodeStartCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-server');
+        const jarPath = discoverJar(repoDir);
+        LOGGER.info(`Found JAR: ${jarPath}`);
+
+        const javaCmd = cli.socket ? `java -jar ${jarPath} --port=5007` : `java -jar ${jarPath} --websocket --port=8081`;
+
+        await execForeground(javaCmd, { cwd: repoDir, verbose: cli.verbose });
+    });
+
+interface ServerNodeStartCliOptions {
+    dir?: string;
+    socket: boolean;
+    verbose: boolean;
+}
+
+export const ServerNodeStartCommand = baseCommand()
+    .name('start')
+    .description('Start the glsp-server-node GLSP server')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('--socket', 'Use socket connection instead of websocket', false)
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: ServerNodeStartCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<ServerNodeStartCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-server-node');
+        const yarnCmd = cli.socket ? 'yarn start' : 'yarn start:websocket';
+        await execForeground(yarnCmd, { cwd: repoDir, verbose: cli.verbose });
+    });

--- a/dev-packages/cli/src/commands/repo/subrepos.ts
+++ b/dev-packages/cli/src/commands/repo/subrepos.ts
@@ -1,0 +1,86 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from 'commander';
+import { GLSPRepo, baseCommand } from '../../util';
+import { createScopedBuildCommand } from './build';
+import { createScopedCloneCommand } from './clone';
+import { createScopedLogCommand } from './log';
+import { TheiaOpenCommand } from './open';
+import { createScopedPwdCommand } from './pwd';
+import { ClientStartCommand, ServerNodeStartCommand, ServerStartCommand, TheiaStartCommand } from './start';
+import { createScopedSwitchCommand } from './switch';
+import { VscodePackageCommand, VsixPathCommand } from './vscode';
+
+const SHORT_ALIASES: Partial<Record<GLSPRepo, string>> = {
+    'glsp-client': 'client',
+    'glsp-server-node': 'server-node',
+    'glsp-theia-integration': 'theia',
+    'glsp-vscode-integration': 'vscode',
+    'glsp-eclipse-integration': 'eclipse',
+    'glsp-server': 'server-java',
+    'glsp-playwright': 'playwright'
+};
+
+const START_COMMANDS: Partial<Record<GLSPRepo, Command>> = {
+    'glsp-client': ClientStartCommand,
+    'glsp-server-node': ServerNodeStartCommand,
+    'glsp-server': ServerStartCommand,
+    'glsp-theia-integration': TheiaStartCommand
+};
+
+const OPEN_COMMANDS: Partial<Record<GLSPRepo, Command>> = {
+    'glsp-theia-integration': TheiaOpenCommand
+};
+
+const EXTRA_COMMANDS: Partial<Record<GLSPRepo, Command[]>> = {
+    'glsp-vscode-integration': [VsixPathCommand, VscodePackageCommand]
+};
+
+export function createSubrepoCommand(repo: GLSPRepo): Command {
+    const cmd = baseCommand()
+        .name(repo)
+        .description(`Operations on the ${repo} repository`)
+        .addCommand(createScopedCloneCommand(repo))
+        .addCommand(createScopedSwitchCommand(repo))
+        .addCommand(createScopedBuildCommand(repo))
+        .addCommand(createScopedPwdCommand(repo))
+        .addCommand(createScopedLogCommand(repo));
+
+    const startCmd = START_COMMANDS[repo];
+    if (startCmd) {
+        cmd.addCommand(startCmd);
+    }
+
+    const openCmd = OPEN_COMMANDS[repo];
+    if (openCmd) {
+        cmd.addCommand(openCmd);
+    }
+
+    const extraCmds = EXTRA_COMMANDS[repo];
+    if (extraCmds) {
+        for (const extraCmd of extraCmds) {
+            cmd.addCommand(extraCmd);
+        }
+    }
+
+    const alias = SHORT_ALIASES[repo];
+    if (alias) {
+        cmd.alias(alias);
+    }
+
+    return cmd;
+}

--- a/dev-packages/cli/src/commands/repo/switch.spec.ts
+++ b/dev-packages/cli/src/commands/repo/switch.spec.ts
@@ -1,0 +1,121 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as processUtil from '../../util/process-util';
+import * as gitUtil from '../../util/git-util';
+import { createTempDir, cleanupTempDir } from '../../../tests/helpers/test-helper';
+import { validateReposExist } from './common/utils';
+import { SwitchActionOptions, switchSingleRepo, validateReposClean } from './switch';
+
+describe('switch-action', () => {
+    const sandbox = sinon.createSandbox();
+    let tempDir: string;
+    let execStub: sinon.SinonStub;
+
+    function makeOptions(overrides: Partial<SwitchActionOptions> = {}): SwitchActionOptions {
+        return {
+            dir: tempDir,
+            branch: 'main',
+            force: false,
+            verbose: false,
+            ...overrides
+        };
+    }
+
+    function createRepoDirs(...names: string[]): void {
+        for (const name of names) {
+            fs.mkdirSync(path.join(tempDir, name), { recursive: true });
+        }
+    }
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+        execStub = sandbox.stub(processUtil, 'exec').returns('');
+        sandbox.stub(gitUtil, 'hasChanges').returns(false);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        cleanupTempDir(tempDir);
+    });
+
+    describe('validateReposExist', () => {
+        it('should pass when all repos exist', () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).to.not.throw();
+        });
+
+        it('should throw listing missing repos', () => {
+            createRepoDirs('glsp-client');
+            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).to.throw(/not cloned.*glsp-server-node/);
+        });
+    });
+
+    describe('validateReposClean', () => {
+        it('should pass when all repos are clean', () => {
+            createRepoDirs('glsp-client');
+            expect(() => validateReposClean(['glsp-client'], tempDir)).to.not.throw();
+        });
+
+        it('should throw listing dirty repos', () => {
+            createRepoDirs('glsp-client');
+            (gitUtil.hasChanges as sinon.SinonStub).returns(true);
+            expect(() => validateReposClean(['glsp-client'], tempDir)).to.throw(/uncommitted changes.*glsp-client/);
+        });
+    });
+
+    describe('switchSingleRepo', () => {
+        it('should run git checkout with the branch name', () => {
+            createRepoDirs('glsp-client');
+            switchSingleRepo('glsp-client', makeOptions({ branch: 'release/2.0' }));
+            expect(execStub.calledOnce).to.be.true;
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('git checkout');
+            expect(cmd).to.contain('release/2.0');
+        });
+
+        it('should add --force when force is true', () => {
+            createRepoDirs('glsp-client');
+            switchSingleRepo('glsp-client', makeOptions({ branch: 'main', force: true }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('--force');
+        });
+
+        it('should warn and return when branch does not exist', () => {
+            createRepoDirs('glsp-client');
+            execStub.throws(new Error("error: pathspec 'nonexistent' did not match any"));
+            expect(() => switchSingleRepo('glsp-client', makeOptions({ branch: 'nonexistent' }))).to.not.throw();
+        });
+
+        it('should rethrow on other git errors', () => {
+            createRepoDirs('glsp-client');
+            execStub.throws(new Error('fatal: some other error'));
+            expect(() => switchSingleRepo('glsp-client', makeOptions())).to.throw('fatal: some other error');
+        });
+
+        it('should use gh pr checkout for --pr', () => {
+            createRepoDirs('glsp-client');
+            switchSingleRepo('glsp-client', makeOptions({ branch: undefined, pr: '42' }));
+            const cmd = execStub.firstCall.args[0] as string;
+            expect(cmd).to.contain('gh pr checkout 42');
+            expect(cmd).to.contain('-R eclipse-glsp/glsp-client');
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/switch.ts
+++ b/dev-packages/cli/src/commands/repo/switch.ts
@@ -1,0 +1,122 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command, Option } from 'commander';
+import * as path from 'path';
+import { GLSPRepo, LOGGER, baseCommand, checkGHCli, exec, hasChanges } from '../../util';
+import { GLSP_GITHUB_ORG, configureRepoEnv, formatError, resolveWorkspaceDir, validateReposExist } from './common/utils';
+
+// ── Action ──────────────────────────────────────────────────────────────────
+
+export interface SwitchActionOptions {
+    dir: string;
+    branch?: string;
+    pr?: string;
+    force: boolean;
+    verbose: boolean;
+}
+
+export function validateReposClean(repos: GLSPRepo[], dir: string): void {
+    const dirty = repos.filter(repo => hasChanges(path.resolve(dir, repo)));
+    if (dirty.length > 0) {
+        throw new Error(
+            `The following repositories have uncommitted changes: ${dirty.join(', ')}. Commit or stash your changes first, or use --force.`
+        );
+    }
+}
+
+export function switchSingleRepo(repo: GLSPRepo, options: SwitchActionOptions): void {
+    const repoDir = path.resolve(options.dir, repo);
+
+    if (options.pr) {
+        LOGGER.info(`Checking out PR #${options.pr} in ${repo}`);
+        exec(`gh pr checkout ${options.pr} -R ${GLSP_GITHUB_ORG}/${repo}`, { cwd: repoDir });
+        return;
+    }
+
+    const branch = options.branch!;
+    const forceArg = options.force ? ' --force' : '';
+    LOGGER.info(`Switching ${repo} to ${branch}`);
+
+    try {
+        exec(`git checkout${forceArg} ${branch}`, { cwd: repoDir, silent: true });
+    } catch (error) {
+        const message = formatError(error);
+        if (message.includes('did not match any') || message.includes('pathspec')) {
+            LOGGER.warn(`${repo}: branch '${branch}' not found, skipping`);
+            return;
+        }
+        throw error;
+    }
+}
+
+// ── Command ─────────────────────────────────────────────────────────────────
+
+interface SwitchCliOptions {
+    dir?: string;
+    branch?: string;
+    pr?: string;
+    force: boolean;
+    verbose: boolean;
+}
+
+export function createScopedSwitchCommand(repo: GLSPRepo): Command {
+    const cmd = baseCommand()
+        .name('switch')
+        .description(`Switch branch or checkout a PR in ${repo}`)
+        .option('-b, --branch <name>', 'Branch or tag to switch to')
+        .option('-d, --dir <path>', 'Target directory where repos are cloned')
+        .addOption(new Option('--pr <number>', 'PR to checkout via gh CLI').conflicts('branch'))
+        .option('--force', 'Switch even if repos have uncommitted changes', false)
+        .option('-v, --verbose', 'Verbose output', false);
+
+    cmd.action(async (_cmdOptions: SwitchCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<SwitchCliOptions>();
+        configureRepoEnv(cli);
+
+        if (!cli.branch && !cli.pr) {
+            throw new Error('Either --branch or --pr must be specified.');
+        }
+
+        const dir = resolveWorkspaceDir(cli.dir);
+
+        if (cli.pr) {
+            checkGHCli();
+        }
+
+        const options: SwitchActionOptions = {
+            dir,
+            branch: cli.branch,
+            pr: cli.pr,
+            force: cli.force,
+            verbose: cli.verbose
+        };
+
+        validateReposExist([repo], dir);
+        if (!cli.force) {
+            validateReposClean([repo], dir);
+        }
+
+        try {
+            switchSingleRepo(repo, options);
+        } catch (error) {
+            LOGGER.error(`Switching ${repo} failed: ${formatError(error)}`);
+            process.exitCode = 1;
+        }
+    });
+
+    return cmd;
+}

--- a/dev-packages/cli/src/commands/repo/vscode.ts
+++ b/dev-packages/cli/src/commands/repo/vscode.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command } from 'commander';
+import * as path from 'path';
+import { baseCommand, execAsync } from '../../util';
+import { VSIX_TARGET_DIR, configureRepoEnv, discoverNewestFile, resolveWorkspaceDir } from './common/utils';
+
+export const VscodePackageCommand: Command = baseCommand()
+    .name('package')
+    .description('Package the workflow VS Code extension as a VSIX')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+        const cli = thisCmd.opts<{ dir?: string; verbose: boolean }>();
+        configureRepoEnv(cli);
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-vscode-integration');
+        await execAsync('yarn workflow package', { cwd: repoDir, silent: false, env: { FORCE_COLOR: '1' } });
+    });
+
+export const VsixPathCommand: Command = baseCommand()
+    .name('vsix-path')
+    .description('Print the path to the workflow VSIX file')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: unknown, thisCmd: Command) => {
+        const cli = thisCmd.opts<{ dir?: string; verbose: boolean }>();
+        configureRepoEnv(cli);
+        const dir = resolveWorkspaceDir(cli.dir);
+        const repoDir = path.resolve(dir, 'glsp-vscode-integration');
+        const vsixPath = discoverVsix(repoDir);
+        process.stdout.write(vsixPath);
+    });
+
+export function discoverVsix(repoDir: string): string {
+    const vsixDir = path.resolve(repoDir, VSIX_TARGET_DIR);
+    return discoverNewestFile('*.vsix', vsixDir, `No .vsix file found in ${vsixDir}. Run 'glsp repo vscode package' first.`);
+}

--- a/dev-packages/cli/src/commands/repo/workspace.spec.ts
+++ b/dev-packages/cli/src/commands/repo/workspace.spec.ts
@@ -1,0 +1,183 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { GLSPRepo } from '../../util';
+import { cleanupTempDir, createTempDir } from '../../../tests/helpers/test-helper';
+import {
+    WORKSPACE_FILE_NAME,
+    WorkspaceInitOptions,
+    VSCodeWorkspace,
+    discoverWorkspaceFile,
+    generateWorkspaceContent,
+    generateWorkspaceFile
+} from './workspace';
+
+describe('workspace-action', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+        cleanupTempDir(tempDir);
+    });
+
+    function makeOptions(overrides: Partial<WorkspaceInitOptions> = {}): WorkspaceInitOptions {
+        return { verbose: false, ...overrides };
+    }
+
+    describe('generateWorkspaceContent', () => {
+        it('should create folders with relative paths for each repo', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            expect(result.folders).to.have.length(2);
+            expect(result.folders[0]).to.deep.equal({ name: 'glsp-client', path: 'glsp-client' });
+            expect(result.folders[1]).to.deep.equal({ name: 'glsp-server-node', path: 'glsp-server-node' });
+        });
+
+        it('should compute paths relative to custom output location', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const outputPath = path.join(tempDir, 'sub', 'dir', WORKSPACE_FILE_NAME);
+
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions({ outputPath }));
+
+            expect(result.folders[0].path).to.equal(path.join('..', '..', 'glsp-client'));
+        });
+
+        it('should include build, link, and unlink tasks', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            expect(result.tasks.version).to.equal('2.0.0');
+            const labels = result.tasks.tasks.map(t => t.label);
+            expect(labels).to.include('GLSP: Build all');
+            expect(labels).to.include('GLSP: Link');
+            expect(labels).to.include('GLSP: Unlink');
+
+            const buildAll = result.tasks.tasks.find(t => t.label === 'GLSP: Build all')!;
+            expect(buildAll.type).to.equal('shell');
+            expect(buildAll.command).to.equal('npx @eclipse-glsp/cli repo build --no-java');
+            expect(buildAll.group).to.deep.equal({ kind: 'build', isDefault: true });
+        });
+
+        it('should include Java build task when Java repos are present', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            const labels = result.tasks.tasks.map(t => t.label);
+            expect(labels).to.include('GLSP: Build all (incl. Java)');
+        });
+
+        it('should not include Java build task when no Java repos are present', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            const labels = result.tasks.tasks.map(t => t.label);
+            expect(labels).to.not.include('GLSP: Build all (incl. Java)');
+        });
+
+        it('should include preset build tasks for matching strict subsets', () => {
+            const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node', 'glsp-theia-integration'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            const labels = result.tasks.tasks.map(t => t.label);
+            expect(labels).to.include('GLSP: Build core');
+        });
+
+        it('should include extension recommendations', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            expect(result.extensions.recommendations).to.deep.equal([
+                'dbaeumer.vscode-eslint',
+                'esbenp.prettier-vscode',
+                'DavidAnson.vscode-markdownlint'
+            ]);
+        });
+
+        it('should have empty settings', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const result = generateWorkspaceContent(repos, tempDir, makeOptions());
+
+            expect(result.settings).to.deep.equal({});
+        });
+    });
+
+    describe('generateWorkspaceFile', () => {
+        it('should write the workspace file to the dir by default', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const outputFile = generateWorkspaceFile(repos, tempDir, makeOptions());
+
+            expect(outputFile).to.equal(path.join(tempDir, WORKSPACE_FILE_NAME));
+            expect(fs.existsSync(outputFile)).to.be.true;
+
+            const content: VSCodeWorkspace = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+            expect(content.folders).to.have.length(1);
+        });
+
+        it('should write to a custom output path', () => {
+            const repos: GLSPRepo[] = ['glsp-client'];
+            const outputPath = path.join(tempDir, 'custom', 'my.code-workspace');
+
+            const outputFile = generateWorkspaceFile(repos, tempDir, makeOptions({ outputPath }));
+
+            expect(outputFile).to.equal(outputPath);
+            expect(fs.existsSync(outputFile)).to.be.true;
+        });
+
+        it('should overwrite an existing workspace file', () => {
+            const repos1: GLSPRepo[] = ['glsp-client'];
+            const repos2: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
+
+            generateWorkspaceFile(repos1, tempDir, makeOptions());
+            generateWorkspaceFile(repos2, tempDir, makeOptions());
+
+            const outputFile = path.join(tempDir, WORKSPACE_FILE_NAME);
+            const content: VSCodeWorkspace = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
+            expect(content.folders).to.have.length(2);
+        });
+    });
+
+    describe('discoverWorkspaceFile', () => {
+        it('should find a single .code-workspace file', () => {
+            fs.writeFileSync(path.join(tempDir, 'glsp.code-workspace'), '{}');
+            const result = discoverWorkspaceFile(tempDir);
+            expect(result).to.equal(path.join(tempDir, 'glsp.code-workspace'));
+        });
+
+        it('should return undefined when no .code-workspace file exists', () => {
+            const result = discoverWorkspaceFile(tempDir);
+            expect(result).to.be.undefined;
+        });
+
+        it('should prefer glsp.code-workspace when multiple exist', () => {
+            fs.writeFileSync(path.join(tempDir, 'glsp.code-workspace'), '{}');
+            fs.writeFileSync(path.join(tempDir, 'other.code-workspace'), '{}');
+            const result = discoverWorkspaceFile(tempDir);
+            expect(result).to.equal(path.join(tempDir, 'glsp.code-workspace'));
+        });
+
+        it('should return undefined for nonexistent directory', () => {
+            const result = discoverWorkspaceFile(path.join(tempDir, 'nonexistent'));
+            expect(result).to.be.undefined;
+        });
+    });
+});

--- a/dev-packages/cli/src/commands/repo/workspace.ts
+++ b/dev-packages/cli/src/commands/repo/workspace.ts
@@ -1,0 +1,220 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Command, Option } from 'commander';
+import { GLSPRepo, LOGGER, PRESETS, PRESET_NAMES, baseCommand, execForeground } from '../../util';
+import { configureRepoEnv, resolveTargetRepos, resolveWorkspaceDir } from './common/utils';
+
+// ── Action: workspace init ──────────────────────────────────────────────────
+
+export const WORKSPACE_FILE_NAME = 'glsp.code-workspace';
+
+export interface WorkspaceInitOptions {
+    outputPath?: string;
+    verbose: boolean;
+}
+
+export interface VSCodeWorkspace {
+    folders: { name: string; path: string }[];
+    settings: Record<string, unknown>;
+    tasks: {
+        version: string;
+        tasks: {
+            label: string;
+            type: string;
+            command: string;
+            group: { kind: string; isDefault: boolean };
+            problemMatcher: string[];
+        }[];
+    };
+    extensions: {
+        recommendations: string[];
+    };
+}
+
+export function generateWorkspaceContent(repos: GLSPRepo[], dir: string, options: WorkspaceInitOptions): VSCodeWorkspace {
+    const outputDir = options.outputPath ? path.dirname(path.resolve(options.outputPath)) : dir;
+
+    const folders = repos.map(repo => {
+        const repoDir = path.resolve(dir, repo);
+        const relativePath = path.relative(outputDir, repoDir);
+        return { name: repo, path: relativePath };
+    });
+
+    const hasJavaRepos = repos.some(r => !GLSPRepo.isNpmRepo(r));
+
+    const tasks: VSCodeWorkspace['tasks']['tasks'] = [];
+
+    tasks.push({
+        label: 'GLSP: Build all',
+        type: 'shell',
+        command: 'npx @eclipse-glsp/cli repo build --no-java',
+        group: { kind: 'build', isDefault: true },
+        problemMatcher: []
+    });
+
+    if (hasJavaRepos) {
+        tasks.push({
+            label: 'GLSP: Build all (incl. Java)',
+            type: 'shell',
+            command: 'npx @eclipse-glsp/cli repo build',
+            group: { kind: 'build', isDefault: false },
+            problemMatcher: []
+        });
+    }
+
+    for (const [presetName, presetRepos] of Object.entries(PRESETS)) {
+        if (presetName === 'all') {
+            continue;
+        }
+        const allPresent = presetRepos.every(r => repos.includes(r));
+        const isStrictSubset = presetRepos.length < repos.length;
+        if (allPresent && isStrictSubset) {
+            tasks.push({
+                label: `GLSP: Build ${presetName}`,
+                type: 'shell',
+                command: `npx @eclipse-glsp/cli repo build --preset ${presetName}`,
+                group: { kind: 'build', isDefault: false },
+                problemMatcher: []
+            });
+        }
+    }
+
+    tasks.push({
+        label: 'GLSP: Link',
+        type: 'shell',
+        command: 'npx @eclipse-glsp/cli repo link',
+        group: { kind: 'none', isDefault: false },
+        problemMatcher: []
+    });
+
+    tasks.push({
+        label: 'GLSP: Unlink',
+        type: 'shell',
+        command: 'npx @eclipse-glsp/cli repo unlink',
+        group: { kind: 'none', isDefault: false },
+        problemMatcher: []
+    });
+
+    return {
+        folders,
+        settings: {},
+        tasks: {
+            version: '2.0.0',
+            tasks
+        },
+        extensions: {
+            recommendations: ['dbaeumer.vscode-eslint', 'esbenp.prettier-vscode', 'DavidAnson.vscode-markdownlint']
+        }
+    };
+}
+
+export function generateWorkspaceFile(repos: GLSPRepo[], dir: string, options: WorkspaceInitOptions): string {
+    const workspace = generateWorkspaceContent(repos, dir, options);
+    const outputFile = options.outputPath ? path.resolve(options.outputPath) : path.join(dir, WORKSPACE_FILE_NAME);
+
+    fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+    fs.writeFileSync(outputFile, JSON.stringify(workspace, undefined, 4) + '\n', 'utf-8');
+    LOGGER.info(`Workspace file written to ${outputFile}`);
+
+    return outputFile;
+}
+
+// ── Action: workspace open ──────────────────────────────────────────────────
+
+export function discoverWorkspaceFile(dir: string): string | undefined {
+    if (!fs.existsSync(dir)) {
+        return undefined;
+    }
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.code-workspace'));
+    if (files.length === 1) {
+        return path.join(dir, files[0]);
+    }
+    if (files.length > 1) {
+        const defaultFile = files.find(f => f === WORKSPACE_FILE_NAME);
+        if (defaultFile) {
+            return path.join(dir, defaultFile);
+        }
+    }
+    return undefined;
+}
+
+async function openWorkspace(workspaceFilePath: string): Promise<void> {
+    LOGGER.info(`Opening workspace ${workspaceFilePath}...`);
+    await execForeground(`code ${workspaceFilePath}`);
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+interface WorkspaceInitCliOptions {
+    dir?: string;
+    verbose: boolean;
+    output?: string;
+    repo?: string[];
+    preset?: string;
+}
+
+const WorkspaceInitCommand = baseCommand()
+    .name('init')
+    .description('Generate a VS Code multi-root workspace file')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('-o, --output <path>', 'Output path for the workspace file')
+    .addOption(new Option('-r, --repo <name...>', 'Include only these repos'))
+    .addOption(new Option('--preset <name>', 'Include repos from a preset').choices(PRESET_NAMES))
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: WorkspaceInitCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<WorkspaceInitCliOptions>();
+        configureRepoEnv(cli);
+
+        const { dir, repos } = resolveTargetRepos(cli);
+
+        generateWorkspaceFile(repos, dir, {
+            outputPath: cli.output,
+            verbose: cli.verbose
+        });
+    });
+
+interface WorkspaceOpenCliOptions {
+    dir?: string;
+    verbose: boolean;
+}
+
+const WorkspaceOpenCommand = baseCommand()
+    .name('open')
+    .description('Open the VS Code workspace file')
+    .option('-d, --dir <path>', 'Target directory where repos are cloned')
+    .option('-v, --verbose', 'Verbose output', false)
+    .action(async (_cmdOptions: WorkspaceOpenCliOptions, thisCmd: Command) => {
+        const cli = thisCmd.opts<WorkspaceOpenCliOptions>();
+        configureRepoEnv(cli);
+
+        const dir = resolveWorkspaceDir(cli.dir);
+        const workspaceFile = discoverWorkspaceFile(dir);
+
+        if (!workspaceFile) {
+            throw new Error(`No .code-workspace file found in '${dir}'.\nRun "glsp repo workspace init" first.`);
+        }
+
+        await openWorkspace(workspaceFile);
+    });
+
+export const WorkspaceCommand = baseCommand()
+    .name('workspace')
+    .description('Manage VS Code workspace files for GLSP projects')
+    .addCommand(WorkspaceInitCommand)
+    .addCommand(WorkspaceOpenCommand);

--- a/dev-packages/cli/src/util/file-util.ts
+++ b/dev-packages/cli/src/util/file-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 EclipseSource and others.
+ * Copyright (c) 2025-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import * as fs from 'fs';
-import { globSync } from 'glob';
 import * as os from 'os';
 import * as path from 'path';
 /**
@@ -124,6 +123,34 @@ export function resolveFiles(files: string[] | string): string[] {
     return filesArray.map(f => path.resolve(f));
 }
 
+export interface GlobOptions {
+    cwd?: string;
+    absolute?: boolean;
+    ignore?: string[];
+    gitignore?: boolean;
+    onlyFiles?: boolean;
+    markDirectories?: boolean;
+    ignoreFiles?: string;
+}
+
+type GlobbySync = (patterns: string | string[], options?: GlobOptions) => string[];
+
+let _globbySync: GlobbySync | undefined;
+const _globbyReady: Promise<void> = import('globby').then(m => {
+    _globbySync = m.globbySync as GlobbySync;
+});
+
+export async function initGlobby(): Promise<void> {
+    await _globbyReady;
+}
+
+export function globby(patterns: string | string[], options?: GlobOptions): string[] {
+    if (!_globbySync) {
+        throw new Error('globby not initialized. Call initGlobby() before using glob functions.');
+    }
+    return _globbySync(patterns, options);
+}
+
 /**
  * Finds all files and directories matching the given pattern.
  * @param paths The file or directory paths to search. If a path is a directory, all
@@ -140,13 +167,10 @@ export function findFiles(paths: string[] | string, pattern = '**/*'): string[] 
             throw new Error(`no such file or directory: ${inputPath}`);
         }
 
-        // If it's a directory, find all files and directories recursively
         if (fs.statSync(inputPath).isDirectory()) {
-            const matches = globSync(pattern, {
+            const matches = globby(pattern, {
                 cwd: inputPath,
-                absolute: true,
-                dot: false
-                // Note: no nodir option, so it includes both files and directories
+                absolute: true
             });
 
             results.push(...matches);

--- a/dev-packages/cli/src/util/glsp-repo-util.spec.ts
+++ b/dev-packages/cli/src/util/glsp-repo-util.spec.ts
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { GLSPRepo, resolveRepoFilter } from './index';
+
+describe('repo-filter', () => {
+    describe('resolveRepoFilter', () => {
+        const configuredRepos: GLSPRepo[] = ['glsp-client', 'glsp-server-node', 'glsp-theia-integration'];
+
+        it('should return configured repos when no filter is specified', () => {
+            const result = resolveRepoFilter(configuredRepos, {});
+            expect(result).to.deep.equal(configuredRepos);
+        });
+
+        it('should filter to specific repos with --repo', () => {
+            const result = resolveRepoFilter(configuredRepos, { repo: ['glsp-client'] });
+            expect(result).to.deep.equal(['glsp-client']);
+        });
+
+        it('should allow repos not in config with --repo', () => {
+            const result = resolveRepoFilter(configuredRepos, { repo: ['glsp-playwright'] });
+            expect(result).to.deep.equal(['glsp-playwright']);
+        });
+
+        it('should expand preset with --preset', () => {
+            const result = resolveRepoFilter(configuredRepos, { preset: 'core' });
+            expect(result).to.include('glsp-client');
+            expect(result).to.include('glsp-server-node');
+        });
+
+        it('should throw for unknown preset', () => {
+            expect(() => resolveRepoFilter(configuredRepos, { preset: 'nonexistent' })).to.throw(/Unknown preset/);
+        });
+
+        it('should throw for unknown repo name', () => {
+            expect(() => resolveRepoFilter(configuredRepos, { repo: ['not-a-repo'] })).to.throw(/Unknown repository/);
+        });
+    });
+});

--- a/dev-packages/cli/src/util/glsp-repo-util.ts
+++ b/dev-packages/cli/src/util/glsp-repo-util.ts
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Copyright (c) 2025-2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { LOGGER } from './logger';
+import { PackageHelper } from './package-util';
+import { exec } from './process-util';
+import { getRemoteUrl } from './git-util';
+
+export type GLSPRepo = (typeof GLSPRepo.choices)[number];
+export namespace GLSPRepo {
+    export const choices = [
+        'glsp',
+        'glsp-server-node',
+        'glsp-client',
+        'glsp-theia-integration',
+        'glsp-vscode-integration',
+        'glsp-eclipse-integration',
+        'glsp-server',
+        'glsp-playwright'
+    ] as const;
+
+    export function is(object: unknown): object is GLSPRepo {
+        return typeof object === 'string' && choices.includes(object as GLSPRepo);
+    }
+
+    export function isNpmRepo(repo: string): boolean {
+        return repo !== 'glsp-server' && repo !== 'glsp-eclipse-integration';
+    }
+
+    export function deriveFromDirectory(repoDir: string): GLSPRepo | undefined {
+        const remoteUrl = getRemoteUrl(repoDir);
+        const repo = remoteUrl.substring(remoteUrl.lastIndexOf('/') + 1).replace('.git', '');
+        if (!repo) {
+            LOGGER.warn(`No git repository found in ${repoDir}`);
+            return undefined;
+        }
+        if (!is(repo)) {
+            return undefined;
+        }
+        return repo;
+    }
+}
+
+export function checkGHCli(): void {
+    LOGGER.debug('Verify that Github CLI is configured correctly');
+    if (!isGithubCLIAuthenticated()) {
+        throw new Error("Github CLI is not configured properly. No user is logged in for host 'github.com'");
+    }
+}
+
+export function isGithubCLIAuthenticated(): boolean {
+    LOGGER.debug('Verify that Github CLI is installed');
+    try {
+        exec('which gh', { silent: true });
+    } catch {
+        LOGGER.debug('Github CLI is not installed.');
+        return false;
+    }
+
+    try {
+        exec('gh auth status');
+    } catch (error) {
+        LOGGER.debug('Github CLI authentication status could not be determined.');
+        return false;
+    }
+    LOGGER.debug('Github CLI is authenticated and ready to use');
+    return true;
+}
+
+let cachedDefaultProtocol: 'gh' | 'https' | undefined;
+
+export function resolveDefaultProtocol(): 'gh' | 'https' {
+    if (cachedDefaultProtocol === undefined) {
+        cachedDefaultProtocol = isGithubCLIAuthenticated() ? 'gh' : 'https';
+        if (cachedDefaultProtocol === 'https') {
+            LOGGER.warn('GitHub CLI not available. Defaulting to HTTPS protocol.');
+        }
+    }
+    return cachedDefaultProtocol;
+}
+
+export function getGLSPDependencies(pkg: PackageHelper): string[] {
+    const deps = pkg.content.dependencies ? Object.keys(pkg.content.dependencies) : [];
+    const devDeps = pkg.content.devDependencies ? Object.keys(pkg.content.devDependencies) : [];
+    return [...deps, ...devDeps].filter(dep => dep.startsWith('@eclipse-glsp'));
+}
+
+// ── Repo presets & filtering ────────────────────────────────────────────────
+
+export const PRESETS: Record<string, GLSPRepo[]> = {
+    core: ['glsp-client', 'glsp-server-node'],
+    theia: ['glsp-client', 'glsp-server-node', 'glsp-theia-integration'],
+    vscode: ['glsp-client', 'glsp-server-node', 'glsp-vscode-integration'],
+    eclipse: ['glsp-client', 'glsp-server-node', 'glsp-server', 'glsp-eclipse-integration'],
+    playwright: ['glsp-client', 'glsp-server-node', 'glsp-theia-integration', 'glsp-vscode-integration', 'glsp-playwright'],
+    all: [...GLSPRepo.choices]
+};
+
+export const PRESET_NAMES = Object.keys(PRESETS);
+
+export interface RepoFilterOptions {
+    repo?: string[];
+    preset?: string;
+}
+
+export function resolveRepoFilter(configuredRepos: GLSPRepo[], filter: RepoFilterOptions): GLSPRepo[] {
+    const extraRepos: GLSPRepo[] = [];
+    if (filter.repo && filter.repo.length > 0) {
+        for (const r of filter.repo) {
+            if (!GLSPRepo.is(r)) {
+                throw new Error(`Unknown repository: "${r}". Must be one of: ${GLSPRepo.choices.join(', ')}`);
+            }
+        }
+        extraRepos.push(...(filter.repo as GLSPRepo[]));
+    }
+
+    if (filter.preset) {
+        if (!(filter.preset in PRESETS)) {
+            throw new Error(`Unknown preset: "${filter.preset}". Must be one of: ${Object.keys(PRESETS).join(', ')}`);
+        }
+        const presetRepos = PRESETS[filter.preset];
+        const merged = [...presetRepos];
+        for (const r of extraRepos) {
+            if (!merged.includes(r)) {
+                merged.push(r);
+            }
+        }
+        return merged;
+    }
+
+    if (extraRepos.length > 0) {
+        return extraRepos;
+    }
+
+    return configuredRepos;
+}

--- a/dev-packages/cli/src/util/glsp-repo-util.ts
+++ b/dev-packages/cli/src/util/glsp-repo-util.ts
@@ -116,7 +116,7 @@ export interface RepoFilterOptions {
     preset?: string;
 }
 
-export function resolveRepoFilter(configuredRepos: GLSPRepo[], filter: RepoFilterOptions): GLSPRepo[] {
+export function resolveRepoFilter(configuredRepos: readonly GLSPRepo[], filter: RepoFilterOptions): GLSPRepo[] {
     const extraRepos: GLSPRepo[] = [];
     if (filter.repo && filter.repo.length > 0) {
         for (const r of filter.repo) {
@@ -145,5 +145,5 @@ export function resolveRepoFilter(configuredRepos: GLSPRepo[], filter: RepoFilte
         return extraRepos;
     }
 
-    return configuredRepos;
+    return [...configuredRepos];
 }

--- a/dev-packages/cli/src/util/index.ts
+++ b/dev-packages/cli/src/util/index.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 EclipseSource and others.
+ * Copyright (c) 2025-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,6 +16,7 @@
 
 export * from './file-util';
 export * from './git-util';
+export * from './glsp-repo-util';
 export * from './logger';
 export * from './package-util';
 export * from './process-util';

--- a/dev-packages/cli/src/util/logger.ts
+++ b/dev-packages/cli/src/util/logger.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 EclipseSource and others.
+ * Copyright (c) 2022-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 export interface Logger extends Pick<Console, LogLevel> {
+    label(...args: any[]): void;
     newLine(): void;
 }
 
@@ -34,6 +35,7 @@ export const LOGGER: Logger = {
     error: (...args) => log('error', ...args),
     warn: (...args) => log('warn', ...args),
     debug: (...args) => log('debug', ...args),
+    label: (...args) => console.log('\x1b[34m', '▸', ...args, '\x1b[0m'),
     newLine: () => console.log('')
 } as const;
 

--- a/dev-packages/cli/src/util/process-util.spec.ts
+++ b/dev-packages/cli/src/util/process-util.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { expect } from 'chai';
-import { configureExec, exec } from './process-util';
+import { configureExec, exec, execForeground } from './process-util';
 
 describe('process-util', () => {
     beforeEach(() => {
@@ -44,6 +44,25 @@ describe('process-util', () => {
         it('should return empty string for command with no output', () => {
             const result = exec('true');
             expect(result).to.equal('');
+        });
+    });
+
+    describe('execForeground', () => {
+        it('should resolve on successful command', async () => {
+            await execForeground('true');
+        });
+
+        it('should reject on non-zero exit code', async () => {
+            try {
+                await execForeground('sh -c "exit 1"');
+                expect.fail('should have thrown');
+            } catch (error) {
+                expect((error as Error).message).to.contain('exited with code 1');
+            }
+        });
+
+        it('should pass cwd option', async () => {
+            await execForeground('true', { cwd: '/tmp' });
         });
     });
 });

--- a/dev-packages/cli/src/util/process-util.ts
+++ b/dev-packages/cli/src/util/process-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 EclipseSource and others.
+ * Copyright (c) 2025-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@ import * as child from 'child_process';
 import { Command } from 'commander';
 import * as path from 'path';
 import * as pkg from '../../package.json';
+import { configureLogger } from './logger';
 
 export const COMMAND_VERSION = pkg.version;
 
@@ -91,6 +92,8 @@ export interface ExecOptions {
     cwd?: string;
     /** Custom error message that should be thrown if the command fails */
     errorMsg?: string;
+    /** Additional environment variables merged with process.env */
+    env?: Record<string, string>;
 }
 
 /**
@@ -122,7 +125,8 @@ export function exec(cmd: string, options: ExecOptions = {}): string {
         encoding: 'utf8',
         shell: true,
         cwd,
-        stdio: ['ignore', 'pipe', 'pipe']
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: options.env ? { ...process.env, ...options.env } : undefined
     });
 
     if (result.error || result.status !== 0) {
@@ -170,7 +174,8 @@ export function execAsync(cmd: string, options: ExecOptions = {}): Promise<strin
         const childProcess = child.spawn(command, args, {
             shell: true,
             cwd,
-            stdio: ['ignore', 'pipe', 'pipe']
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: options.env ? { ...process.env, ...options.env } : undefined
         });
 
         let stdout = '';
@@ -214,6 +219,46 @@ export function execAsync(cmd: string, options: ExecOptions = {}): Promise<strin
             } else {
                 reject(new Error(options.errorMsg ?? errorMsg));
             }
+        });
+    });
+}
+
+export interface ExecForegroundOptions {
+    cwd?: string;
+    verbose?: boolean;
+}
+
+export function configureEnv(options: { verbose: boolean }): void {
+    configureLogger(options.verbose);
+    configureExec({ silent: !options.verbose, verbose: options.verbose });
+}
+
+export function execForeground(cmd: string, options: ExecForegroundOptions = {}): Promise<void> {
+    const verbose = options.verbose !== undefined ? options.verbose : globalExecConfig.verbose;
+
+    if (verbose) {
+        console.log(`+ ${cmd}`);
+    }
+
+    return new Promise((resolve, reject) => {
+        const [command, ...args] = cmd.split(' ');
+
+        const childProcess = child.spawn(command, args, {
+            shell: true,
+            cwd: options.cwd,
+            stdio: 'inherit'
+        });
+
+        childProcess.on('close', code => {
+            if (code !== 0) {
+                reject(new Error(`Command "${cmd}" exited with code ${code ?? 1}`));
+                return;
+            }
+            resolve();
+        });
+
+        childProcess.on('error', error => {
+            reject(new Error(`Command "${cmd}" failed: ${error.message}`));
         });
     });
 }

--- a/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
@@ -1,0 +1,124 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cliDiag, runCli } from '../../helpers/cli-helper';
+import { readJson } from '../../helpers/repo-helper';
+import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+describe('repo commands — core (build)', function () {
+    const CORE_REPOS = ['glsp-client', 'glsp-server-node'] as const;
+    let workDir: string;
+
+    before(function () {
+        workDir = createTempDir();
+
+        const cloneResult = runCli(['repo', 'clone', '--preset', 'core', '-d', workDir]);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+
+        const buildResult = runCli(['repo', 'build', '-d', workDir]);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+    });
+
+    after(function () {
+        cleanupTempDir(workDir);
+    });
+
+    // ── Build ──────────────────────────────────────────────────────────────
+
+    describe('build', function () {
+        it('should have built all core repos', function () {
+            for (const repo of CORE_REPOS) {
+                expect(fs.existsSync(path.join(workDir, repo, 'node_modules')), `${repo}/node_modules should exist`).to.be.true;
+            }
+        });
+
+        it('should build with --repo filter', function () {
+            const result = runCli(['repo', 'build', '-d', workDir, '-r', 'glsp-client']);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+        });
+
+        it('should continue on failure with --no-fail-fast', function () {
+            const badDir = createTempDir();
+            try {
+                fs.mkdirSync(path.join(badDir, 'glsp-client'));
+                fs.mkdirSync(path.join(badDir, 'glsp-server-node'));
+                fs.writeFileSync(path.join(badDir, 'glsp-client', 'package.json'), '{"name":"bad","scripts":{"postinstall":"exit 1"}}');
+                fs.writeFileSync(
+                    path.join(badDir, 'glsp-server-node', 'package.json'),
+                    '{"name":"bad","scripts":{"postinstall":"exit 1"}}'
+                );
+
+                const result = runCli(['repo', 'build', '-d', badDir, '--no-fail-fast']);
+                expect(result.exitCode).to.not.equal(0);
+            } finally {
+                cleanupTempDir(badDir);
+            }
+        });
+    });
+
+    // ── Link / Unlink ──────────────────────────────────────────────────────
+
+    describe('link', function () {
+        it('should link core repos', function () {
+            const result = runCli(['repo', 'link', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+            const linkDir = path.join(workDir, '.yarn-link');
+            expect(fs.existsSync(linkDir), '.yarn-link directory should exist').to.be.true;
+
+            const linkedPkgs = fs.readdirSync(path.join(linkDir, '@eclipse-glsp'));
+            expect(linkedPkgs.length).to.be.greaterThan(0);
+        });
+    });
+
+    describe('unlink', function () {
+        it('should unlink core repos', function () {
+            const result = runCli(['repo', 'unlink', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+        });
+    });
+
+    // ── Workspace ──────────────────────────────────────────────────────────
+
+    describe('workspace', function () {
+        it('should generate a .code-workspace file', function () {
+            const result = runCli(['repo', 'workspace', 'init', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+            const wsFile = path.join(workDir, 'glsp.code-workspace');
+            expect(fs.existsSync(wsFile)).to.be.true;
+
+            const ws = readJson(wsFile);
+            const folders = ws.folders as { name: string; path: string }[];
+            expect(folders).to.have.length(2);
+            expect(folders.map(f => f.name)).to.include.members(['glsp-client', 'glsp-server-node']);
+        });
+
+        it('should generate workspace with custom --output path', function () {
+            const customPath = path.join(workDir, 'custom', 'my.code-workspace');
+            const result = runCli(['repo', 'workspace', 'init', '-d', workDir, '-o', customPath]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(fs.existsSync(customPath)).to.be.true;
+
+            const ws = readJson(customPath);
+            const folders = ws.folders as { name: string; path: string }[];
+            expect(folders).to.have.length(2);
+        });
+    });
+});

--- a/dev-packages/cli/tests/e2e/repo/repo-core-clone.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-core-clone.e2e.spec.ts
@@ -1,0 +1,248 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cliDiag, runCli } from '../../helpers/cli-helper';
+import { currentBranch, git, resetRepo } from '../../helpers/repo-helper';
+import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+describe('repo commands — core (clone)', function () {
+    const CORE_REPOS = ['glsp-client', 'glsp-server-node'] as const;
+    let workDir: string;
+
+    before(function () {
+        workDir = createTempDir();
+        const result = runCli(['repo', 'clone', '--preset', 'core', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+    });
+
+    after(function () {
+        cleanupTempDir(workDir);
+    });
+
+    // ── Clone ──────────────────────────────────────────────────────────────
+
+    describe('clone', function () {
+        it('should clone all core repos via --preset', function () {
+            for (const repo of CORE_REPOS) {
+                const repoDir = path.join(workDir, repo);
+                expect(fs.existsSync(repoDir), `${repo} should exist`).to.be.true;
+                expect(fs.existsSync(path.join(repoDir, 'package.json')), `${repo}/package.json should exist`).to.be.true;
+                expect(fs.existsSync(path.join(repoDir, '.git')), `${repo}/.git should exist`).to.be.true;
+            }
+        });
+
+        it('should clone a single repo via scoped command', function () {
+            const singleDir = createTempDir();
+            try {
+                const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir]);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(fs.existsSync(path.join(singleDir, 'glsp-client', 'package.json'))).to.be.true;
+            } finally {
+                cleanupTempDir(singleDir);
+            }
+        });
+
+        it('should clone with --protocol ssh via scoped command', function () {
+            const singleDir = createTempDir();
+            try {
+                const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir, '-p', 'ssh']);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+                const repoDir = path.join(singleDir, 'glsp-client');
+                expect(fs.existsSync(repoDir)).to.be.true;
+                const remoteUrl = git('remote get-url origin', repoDir);
+                expect(remoteUrl).to.contain('git@github.com:');
+            } finally {
+                cleanupTempDir(singleDir);
+            }
+        });
+
+        it('should clone with --branch via scoped command', function () {
+            const singleDir = createTempDir();
+            try {
+                const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir, '-b', 'master']);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+                const repoDir = path.join(singleDir, 'glsp-client');
+                expect(currentBranch(repoDir)).to.equal('master');
+            } finally {
+                cleanupTempDir(singleDir);
+            }
+        });
+
+        it('should clone with positional repo filter', function () {
+            const filterDir = createTempDir();
+            try {
+                const result = runCli(['repo', 'clone', 'glsp-client', '-d', filterDir]);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+                expect(fs.existsSync(path.join(filterDir, 'glsp-client'))).to.be.true;
+                expect(fs.existsSync(path.join(filterDir, 'glsp-server-node'))).to.be.false;
+            } finally {
+                cleanupTempDir(filterDir);
+            }
+        });
+
+        it('should handle --override rename', function () {
+            const overrideDir = createTempDir();
+            try {
+                runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir]);
+                const marker = path.join(overrideDir, 'glsp-client', 'test-marker.txt');
+                fs.writeFileSync(marker, 'original');
+
+                const result = runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir, '--override', 'rename']);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+                const entries = fs.readdirSync(overrideDir).filter(e => e.startsWith('glsp-client_'));
+                expect(entries).to.have.lengthOf(1);
+                expect(fs.readFileSync(path.join(overrideDir, entries[0], 'test-marker.txt'), 'utf-8')).to.equal('original');
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).to.be.true;
+            } finally {
+                cleanupTempDir(overrideDir);
+            }
+        });
+
+        it('should handle --override remove', function () {
+            const overrideDir = createTempDir();
+            try {
+                runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir]);
+                const marker = path.join(overrideDir, 'glsp-client', 'test-marker.txt');
+                fs.writeFileSync(marker, 'original');
+
+                const result = runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir, '--override', 'remove']);
+                expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'test-marker.txt'))).to.be.false;
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).to.be.true;
+            } finally {
+                cleanupTempDir(overrideDir);
+            }
+        });
+    });
+
+    // ── Switch ─────────────────────────────────────────────────────────────
+
+    describe('switch', function () {
+        afterEach(function () {
+            for (const repo of CORE_REPOS) {
+                resetRepo(path.join(workDir, repo));
+                try {
+                    git('checkout master', path.join(workDir, repo));
+                } catch {
+                    // repo may already be on master
+                }
+            }
+        });
+
+        it('should switch branch via scoped command', function () {
+            const repoDir = path.join(workDir, 'glsp-client');
+            const origBranch = currentBranch(repoDir);
+
+            git('checkout -b test-switch-branch', repoDir);
+            git('checkout ' + origBranch, repoDir);
+
+            const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'test-switch-branch', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(currentBranch(repoDir)).to.equal('test-switch-branch');
+
+            git('checkout ' + origBranch, repoDir);
+            git('branch -d test-switch-branch', repoDir);
+        });
+
+        it('should warn when branch does not exist', function () {
+            const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'nonexistent-branch-12345', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+            const combined = result.stdout + result.stderr;
+            expect(combined).to.contain('not found');
+        });
+
+        it('should fail without --force when repo has changes', function () {
+            const repoDir = path.join(workDir, 'glsp-client');
+            fs.writeFileSync(path.join(repoDir, 'dirty-marker.txt'), 'dirty');
+            git('add dirty-marker.txt', repoDir);
+
+            const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'master', '-d', workDir]);
+            expect(result.exitCode).to.not.equal(0);
+
+            resetRepo(repoDir);
+        });
+
+        it('should switch with --force despite dirty state', function () {
+            const repoDir = path.join(workDir, 'glsp-client');
+            const origBranch = currentBranch(repoDir);
+            git('checkout -b test-force-branch', repoDir);
+            git('checkout ' + origBranch, repoDir);
+            fs.writeFileSync(path.join(repoDir, 'dirty-marker.txt'), 'dirty');
+            git('add dirty-marker.txt', repoDir);
+
+            const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'test-force-branch', '--force', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(currentBranch(repoDir)).to.equal('test-force-branch');
+
+            git('checkout ' + origBranch, repoDir);
+            git('branch -D test-force-branch', repoDir);
+        });
+    });
+
+    // ── Pwd ────────────────────────────────────────────────────────────────
+
+    describe('pwd', function () {
+        it('should print resolved paths for all repos', function () {
+            const result = runCli(['repo', 'pwd', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            for (const repo of CORE_REPOS) {
+                expect(result.stdout).to.contain(repo);
+            }
+        });
+
+        it('should print raw tab-separated output', function () {
+            const result = runCli(['repo', 'pwd', '-d', workDir, '--raw']);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            const lines = result.stdout.trim().split('\n');
+            expect(lines).to.have.lengthOf(2);
+            for (const line of lines) {
+                expect(line).to.match(/^glsp-\S+\t\//);
+            }
+        });
+
+        it('should print path for a single repo via scoped command', function () {
+            const result = runCli(['repo', 'glsp-client', 'pwd', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.stdout.trim()).to.equal(path.resolve(workDir, 'glsp-client'));
+        });
+    });
+
+    // ── Log ────────────────────────────────────────────────────────────────
+
+    describe('log', function () {
+        it('should print the last commit for all repos', function () {
+            const result = runCli(['repo', 'log', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.stdout).to.contain('commit');
+            expect(result.stdout).to.contain('Author:');
+        });
+
+        it('should print the last commit for a single repo via scoped command', function () {
+            const result = runCli(['repo', 'glsp-client', 'log', '-d', workDir]);
+            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.stdout).to.contain('commit');
+        });
+    });
+});

--- a/dev-packages/cli/tests/e2e/repo/repo-eclipse.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-eclipse.e2e.spec.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cliDiag, runCli } from '../../helpers/cli-helper';
+import { isMavenAvailable } from '../../helpers/repo-helper';
+import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+describe('repo commands — eclipse', function () {
+    let workDir: string;
+
+    before(function () {
+        if (!isMavenAvailable()) {
+            this.skip();
+        }
+        workDir = createTempDir();
+
+        const cloneResult = runCli([
+            'repo',
+            'clone',
+            'glsp-client',
+            'glsp-server-node',
+            'glsp-server',
+            'glsp-eclipse-integration',
+            '-d',
+            workDir
+        ]);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+
+        const buildResult = runCli(['repo', 'build', '-d', workDir]);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+    });
+
+    after(function () {
+        if (workDir) {
+            cleanupTempDir(workDir);
+        }
+    });
+
+    it('should have built glsp-server with Maven', function () {
+        const targetDir = path.join(workDir, 'glsp-server', 'examples', 'org.eclipse.glsp.example.workflow', 'target');
+        expect(fs.existsSync(targetDir), 'Maven target directory should exist').to.be.true;
+    });
+
+    it('should build glsp-server via scoped command', function () {
+        const result = runCli(['repo', 'glsp-server', 'build', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+    });
+
+    it('should build glsp-eclipse-integration via scoped command', function () {
+        const result = runCli(['repo', 'glsp-eclipse-integration', 'build', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+    });
+});

--- a/dev-packages/cli/tests/e2e/repo/repo-theia.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-theia.e2e.spec.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { cliDiag, runCli } from '../../helpers/cli-helper';
+import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+describe('repo commands — theia', function () {
+    let workDir: string;
+
+    before(function () {
+        workDir = createTempDir();
+
+        const cloneResult = runCli(['repo', 'clone', '--preset', 'theia', '-d', workDir]);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+
+        const buildResult = runCli(['repo', 'build', '-d', workDir]);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+    });
+
+    after(function () {
+        cleanupTempDir(workDir);
+    });
+
+    it('should build theia-integration with scoped build', function () {
+        const result = runCli(['repo', 'glsp-theia-integration', 'build', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+    });
+});

--- a/dev-packages/cli/tests/e2e/repo/repo-vscode.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-vscode.e2e.spec.ts
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import { cliDiag, runCli } from '../../helpers/cli-helper';
+import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+describe('repo commands — vscode', function () {
+    let workDir: string;
+
+    before(function () {
+        workDir = createTempDir();
+
+        const cloneResult = runCli(['repo', 'clone', '--preset', 'vscode', '-d', workDir]);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+
+        const buildResult = runCli(['repo', 'build', '-d', workDir]);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+    });
+
+    after(function () {
+        cleanupTempDir(workDir);
+    });
+
+    it('should build vscode-integration with scoped build', function () {
+        const result = runCli(['repo', 'glsp-vscode-integration', 'build', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+    });
+
+    it('should package the VS Code extension as VSIX', function () {
+        const result = runCli(['repo', 'glsp-vscode-integration', 'package', '-d', workDir]);
+        expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+        const vsixDir = path.join(workDir, 'glsp-vscode-integration', 'example', 'workflow', 'extension');
+        const vsixFiles = fs.readdirSync(vsixDir).filter(f => f.endsWith('.vsix'));
+        expect(vsixFiles).to.have.lengthOf.at.least(1);
+    });
+});

--- a/dev-packages/cli/tests/helpers/cli-helper.ts
+++ b/dev-packages/cli/tests/helpers/cli-helper.ts
@@ -38,7 +38,7 @@ export function runCli(args: string[], options: CliOptions = {}): CliResult {
         cwd: options.cwd ?? process.cwd(),
         encoding: 'utf-8',
         env: { ...process.env, ...options.env },
-        timeout: options.timeout ?? 60000,
+        timeout: options.timeout,
         stdio: ['pipe', 'pipe', 'pipe']
     });
     return {
@@ -46,4 +46,13 @@ export function runCli(args: string[], options: CliOptions = {}): CliResult {
         stdout: result.stdout ?? '',
         stderr: result.stderr ?? ''
     };
+}
+
+/** Returns a concise diagnostic string for assertion messages (last 40 lines of stdout + stderr). */
+export function cliDiag(result: CliResult): string {
+    const tail = (s: string, n: number): string => {
+        const lines = s.trimEnd().split('\n');
+        return lines.length > n ? `…(${lines.length - n} lines omitted)\n${lines.slice(-n).join('\n')}` : s.trimEnd();
+    };
+    return `stdout:\n${tail(result.stdout, 30)}\nstderr:\n${tail(result.stderr, 10)}`;
 }

--- a/dev-packages/cli/tests/helpers/repo-helper.ts
+++ b/dev-packages/cli/tests/helpers/repo-helper.ts
@@ -14,18 +14,31 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { execSync } from 'child_process';
 import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 
-/** Creates a unique temporary directory for test isolation. */
-export function createTempDir(): string {
-    return fs.mkdtempSync(path.join(os.tmpdir(), 'glsp-test-'));
+export function git(args: string, cwd: string): string {
+    return execSync(`git ${args}`, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
 }
 
-/** Removes a temporary directory and all its contents. */
-export function cleanupTempDir(dir: string): void {
-    if (fs.existsSync(dir)) {
-        fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 200 });
+export function readJson(filePath: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+export function resetRepo(repoDir: string): void {
+    git('checkout .', repoDir);
+    git('clean -fd', repoDir);
+}
+
+export function currentBranch(repoDir: string): string {
+    return git('rev-parse --abbrev-ref HEAD', repoDir);
+}
+
+export function isMavenAvailable(): boolean {
+    try {
+        execSync('mvn --version', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+        return true;
+    } catch {
+        return false;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,14 +1449,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/glob@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
-  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
-  dependencies:
-    "@types/minimatch" "^5.1.2"
-    "@types/node" "*"
-
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -1467,11 +1459,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/minimatch@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
-  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
-
 "@types/minimist@^1.2.0":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
@@ -1481,13 +1468,6 @@
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
-
-"@types/node@*":
-  version "20.12.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.11.tgz#c4ef00d3507000d17690643278a60dc55a9dc9be"
-  integrity sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==
-  dependencies:
-    undici-types "~5.26.4"
 
 "@types/node@22.x":
   version "22.19.15"
@@ -2036,6 +2016,13 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+bundle-name@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
+  integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
+  dependencies:
+    run-applescript "^7.0.0"
+
 byte-size@8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-8.1.1.tgz#3424608c62d59de5bfda05d31e0313c6174842ae"
@@ -2564,6 +2551,19 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+default-browser-id@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.1.tgz#f7a7ccb8f5104bf8e0f71ba3b1ccfa5eafdb21e8"
+  integrity sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==
+
+default-browser@^5.2.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.5.0.tgz#2792e886f2422894545947cc80e1a444496c5976"
+  integrity sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==
+  dependencies:
+    bundle-name "^4.1.0"
+    default-browser-id "^5.0.0"
+
 default-require-extensions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-3.0.1.tgz#bfae00feeaeada68c2ae256c62540f60b80625bd"
@@ -2582,6 +2582,11 @@ define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3394,18 +3399,6 @@ glob@^10.2.2, glob@^10.3.7:
     minipass "^7.0.4"
     path-scurry "^1.11.0"
 
-glob@^10.4.5:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
-  dependencies:
-    foreground-child "^3.1.0"
-    jackspeak "^3.1.2"
-    minimatch "^9.0.4"
-    minipass "^7.1.2"
-    package-json-from-dist "^1.0.0"
-    path-scurry "^1.11.1"
-
 glob@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
@@ -3786,6 +3779,11 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3802,6 +3800,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -3878,6 +3883,13 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+is-wsl@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.1.tgz#327897b26832a3eb117da6c27492d04ca132594f"
+  integrity sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==
+  dependencies:
+    is-inside-container "^1.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -3958,15 +3970,6 @@ jackspeak@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
   integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
-  dependencies:
-    "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
-
-jackspeak@^3.1.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
-  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
@@ -5049,6 +5052,16 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^10.0.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
+  integrity sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==
+  dependencies:
+    default-browser "^5.2.1"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    wsl-utils "^0.1.0"
+
 open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -5331,7 +5344,7 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-scurry@^1.11.0, path-scurry@^1.11.1, path-scurry@^1.6.1:
+path-scurry@^1.11.0, path-scurry@^1.6.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
   integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
@@ -5734,6 +5747,11 @@ rimraf@^5.0.1, rimraf@^5.0.5:
   integrity sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==
   dependencies:
     glob "^10.3.7"
+
+run-applescript@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
+  integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
 
 run-async@^4.0.5:
   version "4.0.6"
@@ -6363,11 +6381,6 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
 undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
@@ -6631,6 +6644,13 @@ write-pkg@4.0.0:
     sort-keys "^2.0.0"
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
+
+wsl-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.1.0.tgz#8783d4df671d4d50365be2ee4c71917a0557baab"
+  integrity sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==
+  dependencies:
+    is-wsl "^3.1.0"
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
#### What it does

Add a new `glsp repo` command group for managing multi-repo GLSP development workspaces.
All repositories are expected as siblings in a shared workspace directory (e.g. `~/glsp/glsp-client`, `~/glsp/glsp-server-node`).
Repos are auto-discovered by directory name — no configuration file needed.

Commands include `clone`, `fork`, `build`, `link`/`unlink`, `pwd`, `log`, `workspace`, and `switch` — each available both as top-level multi-repo operations and as per-repo scoped commands (e.g. `glsp repo client start`, `glsp repo theia open`).

Key capabilities:

- Auto-discovery of GLSP repos via sibling directory scanning
- Dependency-aware build ordering via repo graph
- Dual-remote fork setup (`origin`=fork, `upstream`=eclipse-glsp)
- Symlink-based cross-repo linking with singleton deduplication
- Interactive clone wizard (`--interactive`)
- Preset-based repo filtering (`core`, `theia`, `vscode`, `eclipse`, `playwright`, `all`)
- VS Code multi-root workspace generation
- Repo-specific extras: `start`, `open`, `vsix-path`, `package`

Closes #1654

#### How to test

- Unit tests (316) and e2e tests are in place
- `yarn check:all` passes (lint, format, headers, unit tests)
- Manual testing via `yarn glsp repo <command>`


#### Changelog

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
