### PR TITLE
Enable passthrough args for start commands and simplify playwright en…

### DIFF
--- a/dev-packages/cli/src/commands/repo/playwright.spec.ts
+++ b/dev-packages/cli/src/commands/repo/playwright.spec.ts
@@ -56,7 +56,7 @@ describe('playwright-env', () => {
             const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
             const content = generatePlaywrightEnvContent({ dir: tempDir, discoveredRepos: repos });
             expect(content).to.contain('GLSP_SERVER_START_CMD=glsp repo server-node start');
-            expect(content).to.contain('STANDALONE_START_CMD=glsp repo client run start');
+            expect(content).to.contain('STANDALONE_START_CMD=glsp repo client start');
             expect(content).not.to.match(/^# GLSP_SERVER_START_CMD/m);
         });
 

--- a/dev-packages/cli/src/commands/repo/playwright.ts
+++ b/dev-packages/cli/src/commands/repo/playwright.ts
@@ -50,11 +50,11 @@ export function generatePlaywrightEnvContent(options: PlaywrightEnvOptions): str
     if (hasServerNode && hasClient) {
         lines.push('# Standalone Node (WebSocket)');
         lines.push('GLSP_SERVER_START_CMD=glsp repo server-node start');
-        lines.push('STANDALONE_START_CMD=glsp repo client run start -- --external-server --no-open');
+        lines.push('STANDALONE_START_CMD=glsp repo client start --external-server --no-open');
     } else {
         lines.push('# Standalone Node (WebSocket) — missing repos, uncomment when available');
         lines.push('# GLSP_SERVER_START_CMD=glsp repo server-node start');
-        lines.push('# STANDALONE_START_CMD=glsp repo client run start -- --external-server --no-open');
+        lines.push('# STANDALONE_START_CMD=glsp repo client start --external-server --no-open');
     }
     lines.push('');
 
@@ -63,14 +63,14 @@ export function generatePlaywrightEnvContent(options: PlaywrightEnvOptions): str
         const bundleExists = fs.existsSync(bundlePath);
         lines.push('# Standalone Browser (Web Worker)');
         if (bundleExists) {
-            lines.push(`STANDALONE_BROWSER_START_CMD=glsp repo client run start:browser -- --external-server ${bundlePath} --no-open`);
+            lines.push(`STANDALONE_BROWSER_START_CMD=glsp repo client start --browser --external-server ${bundlePath} --no-open`);
         } else {
             LOGGER.warn(`Browser bundle not found at ${bundlePath}. Build glsp-server-node first.`);
-            lines.push(`# STANDALONE_BROWSER_START_CMD=glsp repo client run start:browser -- --external-server ${bundlePath} --no-open`);
+            lines.push(`# STANDALONE_BROWSER_START_CMD=glsp repo client start --browser --external-server ${bundlePath} --no-open`);
         }
     } else {
         lines.push('# Standalone Browser (Web Worker) — missing repos, uncomment when available');
-        lines.push('# STANDALONE_BROWSER_START_CMD=glsp repo client run start:browser -- --external-server <bundle-path> --no-open');
+        lines.push('# STANDALONE_BROWSER_START_CMD=glsp repo client start --browser --external-server <bundle-path> --no-open');
     }
     lines.push('');
 

--- a/dev-packages/cli/src/commands/repo/run.spec.ts
+++ b/dev-packages/cli/src/commands/repo/run.spec.ts
@@ -40,5 +40,10 @@ describe('run-command', () => {
             const cmd = createScopedRunCommand('glsp-client');
             expect((cmd as any)._allowUnknownOption).to.be.true;
         });
+
+        it('should allow excess arguments for passthrough', () => {
+            const cmd = createScopedRunCommand('glsp-client');
+            expect((cmd as any)._allowExcessArguments).to.be.true;
+        });
     });
 });

--- a/dev-packages/cli/src/commands/repo/run.ts
+++ b/dev-packages/cli/src/commands/repo/run.ts
@@ -23,6 +23,7 @@ export function createScopedRunCommand(repo: GLSPRepo): Command {
     return baseCommand()
         .name('run')
         .allowUnknownOption(true)
+        .allowExcessArguments(true)
         .description(`Run an arbitrary yarn script in ${repo}`)
         .argument('<script>', 'The yarn script to run')
         .option('-d, --dir <path>', 'Target directory where repos are cloned')

--- a/dev-packages/cli/src/commands/repo/start.spec.ts
+++ b/dev-packages/cli/src/commands/repo/start.spec.ts
@@ -18,7 +18,14 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { cleanupTempDir, createTempDir } from '../../../tests/helpers/test-helper';
-import { JAR_TARGET_DIR, discoverJar } from './start';
+import {
+    JAR_TARGET_DIR,
+    ClientStartCommand,
+    ServerNodeStartCommand,
+    ServerStartCommand,
+    TheiaStartCommand,
+    discoverJar
+} from './start';
 
 describe('start-action', () => {
     let tempDir: string;
@@ -72,5 +79,24 @@ describe('start-action', () => {
         it('should throw with helpful message when target directory does not exist', () => {
             expect(() => discoverJar(tempDir)).to.throw(/glsp repo server build/);
         });
+    });
+
+    describe('start commands allow passthrough args', () => {
+        const commands = [
+            { name: 'ClientStartCommand', cmd: ClientStartCommand },
+            { name: 'TheiaStartCommand', cmd: TheiaStartCommand },
+            { name: 'ServerStartCommand', cmd: ServerStartCommand },
+            { name: 'ServerNodeStartCommand', cmd: ServerNodeStartCommand }
+        ];
+
+        for (const { name, cmd } of commands) {
+            it(`${name} should allow unknown options`, () => {
+                expect((cmd as any)._allowUnknownOption).to.be.true;
+            });
+
+            it(`${name} should allow excess arguments`, () => {
+                expect((cmd as any)._allowExcessArguments).to.be.true;
+            });
+        }
     });
 });

--- a/dev-packages/cli/src/commands/repo/start.ts
+++ b/dev-packages/cli/src/commands/repo/start.ts
@@ -29,6 +29,13 @@ export function discoverJar(repoDir: string): string {
     return discoverNewestFile(JAR_PATTERN, targetDir, `No *-glsp.jar found in ${targetDir}. Run \`glsp repo server build\` first.`);
 }
 
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function collectPassthroughArgs(cmd: Command): string {
+    const raw = cmd.args;
+    return raw.length > 0 ? ` ${raw.join(' ')}` : '';
+}
+
 // ── Commands ────────────────────────────────────────────────────────────────
 
 interface TheiaStartCliOptions {
@@ -40,6 +47,8 @@ interface TheiaStartCliOptions {
 
 export const TheiaStartCommand = baseCommand()
     .name('start')
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
     .description('Start the Theia application for glsp-theia-integration')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .option('--electron', 'Start electron variant instead of browser', false)
@@ -53,7 +62,8 @@ export const TheiaStartCommand = baseCommand()
         const repoDir = path.resolve(dir, 'glsp-theia-integration');
         const target = cli.electron ? 'electron' : 'browser';
         const script = cli.debug ? 'start:debug' : 'start';
-        await execForeground(`yarn ${target} ${script}`, { cwd: repoDir, verbose: cli.verbose });
+        const passthrough = collectPassthroughArgs(thisCmd);
+        await execForeground(`yarn ${target} ${script}${passthrough}`, { cwd: repoDir, verbose: cli.verbose });
     });
 
 interface ClientStartCliOptions {
@@ -64,6 +74,8 @@ interface ClientStartCliOptions {
 
 export const ClientStartCommand = baseCommand()
     .name('start')
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
     .description('Start the standalone example for glsp-client')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .option('--browser', 'Run in browser-only mode with WebWorker server', false)
@@ -75,11 +87,14 @@ export const ClientStartCommand = baseCommand()
         const dir = resolveWorkspaceDir(cli.dir);
         const repoDir = path.resolve(dir, 'glsp-client');
         const script = cli.browser ? 'start:browser' : 'start';
-        await execForeground(`yarn ${script}`, { cwd: repoDir, verbose: cli.verbose });
+        const passthrough = collectPassthroughArgs(thisCmd);
+        await execForeground(`yarn ${script}${passthrough}`, { cwd: repoDir, verbose: cli.verbose });
     });
 
 export const ServerStartCommand = baseCommand()
     .name('start')
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
     .description('Start the glsp-server Java GLSP server')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .option('-p, --port <port>', 'Port to start the server on')
@@ -97,8 +112,8 @@ export const ServerStartCommand = baseCommand()
         const socketPort = cli.port ?? 5007;
         const wsPort = cli.port ?? 8081;
         const javaCmd = cli.socket ? `java -jar ${jarPath} --port=${socketPort}` : `java -jar ${jarPath} --websocket --port=${wsPort}`;
-
-        await execForeground(javaCmd, { cwd: repoDir, verbose: cli.verbose });
+        const passthrough = collectPassthroughArgs(thisCmd);
+        await execForeground(`${javaCmd}${passthrough}`, { cwd: repoDir, verbose: cli.verbose });
     });
 
 interface ServerNodeStartCliOptions {
@@ -110,6 +125,8 @@ interface ServerNodeStartCliOptions {
 
 export const ServerNodeStartCommand = baseCommand()
     .name('start')
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
     .description('Start the glsp-server-node GLSP server')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .option('-p, --port <port>', 'Port to start the server on')
@@ -123,5 +140,6 @@ export const ServerNodeStartCommand = baseCommand()
         const repoDir = path.resolve(dir, 'glsp-server-node');
         const yarnCmd = cli.socket ? 'yarn start' : 'yarn start:websocket';
         const portArg = cli.port ? ` --port ${cli.port}` : '';
-        await execForeground(`${yarnCmd}${portArg}`, { cwd: repoDir, verbose: cli.verbose });
+        const passthrough = collectPassthroughArgs(thisCmd);
+        await execForeground(`${yarnCmd}${portArg}${passthrough}`, { cwd: repoDir, verbose: cli.verbose });
     });


### PR DESCRIPTION
…v commands

- Add allowUnknownOption/allowExcessArguments to all start commands
- Collect and forward passthrough args via collectPassthroughArgs helper
- Add allowExcessArguments to run command
- Use `client start` directly in playwright env instead of `client run start`
- Add unit tests for passthrough support on start and run commands

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
