### PR TITLE
Use batch mode for CLI maven commands

### DIFF
--- a/dev-packages/cli/src/commands/repo/build.spec.ts
+++ b/dev-packages/cli/src/commands/repo/build.spec.ts
@@ -80,7 +80,7 @@ describe('build-action', () => {
             createRepoDirs('glsp-server');
             await buildSingleRepo('glsp-server', makeOptions());
             expect(execAsyncStub.calledOnce).to.be.true;
-            expect(execAsyncStub.firstCall.args[0]).to.equal('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always');
+            expect(execAsyncStub.firstCall.args[0]).to.equal('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B');
         });
 
         it('should build client and server for eclipse-integration', async () => {
@@ -89,7 +89,7 @@ describe('build-action', () => {
             expect(execAsyncStub.callCount).to.equal(2);
             expect(execAsyncStub.firstCall.args[0]).to.equal('yarn');
             expect(execAsyncStub.firstCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
-            expect(execAsyncStub.secondCall.args[0]).to.equal('mvn clean verify -Dstyle.color=always');
+            expect(execAsyncStub.secondCall.args[0]).to.equal('mvn clean verify -Dstyle.color=always -B');
             expect(execAsyncStub.secondCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'server'));
         });
     });

--- a/dev-packages/cli/src/commands/repo/build.ts
+++ b/dev-packages/cli/src/commands/repo/build.ts
@@ -45,14 +45,14 @@ export async function buildSingleRepo(repo: GLSPRepo, options: BuildActionOption
             break;
         }
         case 'glsp-server': {
-            await execAsync('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always', mvnOpts);
+            await execAsync('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B', mvnOpts);
             break;
         }
         case 'glsp-eclipse-integration': {
             LOGGER.debug('Yarn build for client');
             await execAsync('yarn', { ...yarnOpts, cwd: path.join(repoDir, 'client') });
             LOGGER.debug('Maven build for server');
-            await execAsync('mvn clean verify -Dstyle.color=always', { ...mvnOpts, cwd: path.join(repoDir, 'server') });
+            await execAsync('mvn clean verify -Dstyle.color=always -B', { ...mvnOpts, cwd: path.join(repoDir, 'server') });
             break;
         }
         default: {

--- a/dev-packages/cli/src/commands/repo/repo.spec.ts
+++ b/dev-packages/cli/src/commands/repo/repo.spec.ts
@@ -19,9 +19,7 @@ import { Command } from 'commander';
 import { baseCommand } from '../../util';
 
 function createParentWithHook(): Command {
-    const parent = baseCommand()
-        .name('repo')
-        .option('-d, --dir <path>', 'Target directory');
+    const parent = baseCommand().name('repo').option('-d, --dir <path>', 'Target directory');
 
     parent.hook('preSubcommand', (_, subcommand) => {
         const parentDir = parent.opts().dir;
@@ -44,9 +42,7 @@ function createLeaf(captured: { dir?: string }): Command {
 }
 
 function createMiddleWithHook(): Command {
-    const mid = baseCommand()
-        .name('middle')
-        .description('Middle layer');
+    const mid = baseCommand().name('middle').description('Middle layer');
 
     mid.hook('preSubcommand', (_, subcommand) => {
         const parentDir = mid.getOptionValue('dir');


### PR DESCRIPTION
Ensure that all mvn CLI commands use -B (batchmode). Otherwise the logoutput gets convoluted

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
