### PR TITLE
Migrate ts-config target to ES2023

### DIFF
--- a/dev-packages/cli/src/commands/repo/link.ts
+++ b/dev-packages/cli/src/commands/repo/link.ts
@@ -171,7 +171,7 @@ export async function runUnlink(repos: GLSPRepo[], options: LinkActionOptions): 
     validateReposExist(linkable, options.dir);
     const linkDir = path.resolve(options.dir, '.yarn-link');
     const ordered = getBuildOrder(linkable);
-    const reversed = [...ordered].reverse();
+    const reversed = ordered.toReversed();
     let failures = 0;
 
     LOGGER.label('Unlinking repositories');

--- a/dev-packages/cli/src/util/process-util.ts
+++ b/dev-packages/cli/src/util/process-util.ts
@@ -110,9 +110,9 @@ export interface ExecOptions {
  */
 export function exec(cmd: string, options: ExecOptions = {}): string {
     // Merge global config with local options (local options take precedence)
-    const silent = options.silent !== undefined ? options.silent : globalExecConfig.silent;
-    const fatal = options.fatal !== undefined ? options.fatal : globalExecConfig.fatal;
-    const verbose = options.verbose !== undefined ? options.verbose : globalExecConfig.verbose;
+    const silent = options.silent ?? globalExecConfig.silent;
+    const fatal = options.fatal ?? globalExecConfig.fatal;
+    const verbose = options.verbose ?? globalExecConfig.verbose;
     const { cwd } = options;
 
     if (verbose) {
@@ -159,9 +159,9 @@ export function exec(cmd: string, options: ExecOptions = {}): string {
  */
 export function execAsync(cmd: string, options: ExecOptions = {}): Promise<string> {
     // Merge global config with local options (local options take precedence)
-    const silent = options.silent !== undefined ? options.silent : globalExecConfig.silent;
-    const fatal = options.fatal !== undefined ? options.fatal : globalExecConfig.fatal;
-    const verbose = options.verbose !== undefined ? options.verbose : globalExecConfig.verbose;
+    const silent = options.silent ?? globalExecConfig.silent;
+    const fatal = options.fatal ?? globalExecConfig.fatal;
+    const verbose = options.verbose ?? globalExecConfig.verbose;
     const { cwd } = options;
 
     if (verbose) {
@@ -234,7 +234,7 @@ export function configureEnv(options: { verbose: boolean }): void {
 }
 
 export function execForeground(cmd: string, options: ExecForegroundOptions = {}): Promise<void> {
-    const verbose = options.verbose !== undefined ? options.verbose : globalExecConfig.verbose;
+    const verbose = options.verbose ?? globalExecConfig.verbose;
 
     if (verbose) {
         console.log(`+ ${cmd}`);

--- a/dev-packages/ts-config/package.json
+++ b/dev-packages/ts-config/package.json
@@ -30,7 +30,7 @@
     "mocha.json"
   ],
   "peerDependencies": {
-    "typescript": ">=5.x"
+    "typescript": ">=5.5"
   },
   "publishConfig": {
     "access": "public"

--- a/dev-packages/ts-config/tsconfig.json
+++ b/dev-packages/ts-config/tsconfig.json
@@ -15,14 +15,16 @@
     "incremental": true,
     // Needs to be disabled to support property injection
     "strictPropertyInitialization": false,
+    // Needs to be disabled to support property injection
+    "useDefineForClassFields": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "resolveJsonModule": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES2019",
+    "target": "ES2023",
     "jsx": "react",
-    "lib": ["ES2019", "dom"],
+    "lib": ["ES2023", "dom"],
     "sourceMap": true,
     "types": ["node", "reflect-metadata"]
   }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Bump shared ts-config target/lib to ES2023; set useDefineForClassFields false to preserve property injection
- Use nullish coalescing for exec option resolution in process-util
- Use Array.toReversed() in the repo unlink command

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
