### PR TITLE
GLSP-1636: Rework cross-repo linking and finish the pnpm-only CLI

### DIFF
--- a/dev-packages/cli/README.md
+++ b/dev-packages/cli/README.md
@@ -63,8 +63,7 @@ Options:
 
 ## coverageReport
 
-The `coverageReport` command can be used to create a full nyc test coverage report for a pnpm/yarn mono repository.
-The package manager is auto-detected from the repository (pnpm-workspace.yaml/pnpm-lock.yaml vs. yarn.lock).
+The `coverageReport` command can be used to create a full nyc test coverage report for a pnpm mono repository.
 Individual coverage reports for each package are created and then combined to a full report.
 
 ```console
@@ -203,9 +202,7 @@ Options:
 
 ### publish
 
-Publishes all (public) workspace packages of a GLSP repository (replaces `lerna publish`).
-The package manager is auto-detected: pnpm-based repositories publish via `pnpm publish -r`, while
-not-yet-migrated yarn/lerna-based repositories fall back to the legacy `lerna publish`.
+Publishes all (public) workspace packages of a GLSP repository via `pnpm publish -r` (replaces `lerna publish`).
 
 - `next`: applies a canary version (`<root-version>.<commits-since-last-tag>`, e.g. `2.8.0-next.42`) to all
   workspace packages and publishes them under the `next` dist-tag. Requires the full git history
@@ -213,15 +210,14 @@ not-yet-migrated yarn/lerna-based repositories fall back to the legacy `lerna pu
 - `latest`: publishes the current package versions under the `latest` dist-tag. Packages whose version
   already exists on the registry are skipped.
 
-For pnpm repositories publishing is delegated to `pnpm publish -r`, so `workspace:` dependency ranges are
-rewritten to exact versions; in both cases npm provenance/trusted publishing (`NPM_CONFIG_PROVENANCE`) is
-preserved. `--dry-run` is only supported for pnpm-based repositories.
+Publishing is delegated to `pnpm publish -r`, so `workspace:` dependency ranges are rewritten to exact
+versions; npm provenance/trusted publishing (`NPM_CONFIG_PROVENANCE`) is preserved.
 
 ```console
 $ glsp releng publish -h
 Usage: glsp releng publish [options] <distTag>
 
-Publish all workspace packages of a GLSP repository (pnpm: `pnpm publish`, yarn/lerna: `lerna publish`)
+Publish all workspace packages of a GLSP repository via `pnpm publish`
 
 Arguments:
   distTag                  The npm dist-tag to publish under (choices: "next", "latest")
@@ -256,8 +252,8 @@ Commands:
   clone [options] [repos...]        Clone GLSP repositories
   fork [options] <user>             Add fork remotes to already-cloned repositories
   build [options]                   Build repositories (dependency-ordered)
-  link [options]                    Interlink repositories via yarn link
-  unlink [options]                  Remove yarn links between repositories
+  link [options]                    Interlink repositories via pnpm-workspace.yaml link overrides
+  unlink [options]                  Remove the pnpm link overrides between repositories
   pwd [options]                     Print resolved paths for all discovered repositories
   log [options]                     Print the last commit for all discovered repositories
   workspace                         Manage VS Code workspace files for GLSP projects
@@ -349,21 +345,30 @@ Options:
 
 ### link / unlink
 
-Links (or unlinks) repositories via `yarn link` for cross-repo development.
-Repositories are processed in dependency order, and singleton dependencies (sprotty, inversify, etc.)
-are shared from `glsp-client` to avoid duplicate instances.
+Links (or unlinks) repositories for cross-repo development by injecting `link:` overrides into each
+consumer's `pnpm-workspace.yaml` and reinstalling. Repositories are processed in dependency order, and
+singleton dependencies (sprotty, sprotty-protocol, vscode-jsonrpc, inversify) are shared from `glsp-client`
+to avoid duplicate instances. After linking a repo it is **built** so the `link:` overrides resolve to
+compiled `lib/` output rather than empty source directories (pass `--no-build` to skip); only the npm/pnpm
+side is built, so the `glsp-eclipse-integration` Maven server is left to a separate build. `unlink` removes
+those overrides again and reinstalls.
+
+For `glsp-eclipse-integration`, whose linkable pnpm workspace lives in a `client/` subdirectory, the
+overrides are injected into `client/pnpm-workspace.yaml`.
 
 ```console
 $ glsp repo link -h
 Usage: glsp repo link [options]
 
-Interlink repositories via yarn link
+Interlink repositories via pnpm-workspace.yaml link overrides
 
 Options:
   -d, --dir <path>      Target directory where repos are cloned
   -r, --repo <name...>  Link only these repos
   --preset <name>       Link repos from a preset (choices: "core", "theia", "vscode",
                         "eclipse", "playwright", "all")
+  --no-build            Skip building the linked repos (links resolve to existing compiled output)
+  --electron            Build the Theia electron variant instead of browser (default: false)
   --no-fail-fast        Continue after a failure
   -v, --verbose         Verbose output (default: false)
   -h, --help            display help for command

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -46,7 +46,6 @@
     "watch:tsc": "tsc --watch"
   },
   "devDependencies": {
-    "@eclipse-glsp/config": "workspace:*",
     "@types/semver": "^7.7.1",
     "commander": "^14.0.0",
     "esbuild": "~0.28.1",

--- a/dev-packages/cli/src/commands/coverage-report.ts
+++ b/dev-packages/cli/src/commands/coverage-report.ts
@@ -21,14 +21,11 @@ import {
     PackageHelper,
     baseCommand,
     cd,
-    detectPackageManager,
     exec,
     execAsync,
-    execBinCommand,
     findFiles,
     getWorkspacePackages,
     moveFile,
-    runScriptCommand,
     validateDirectory
 } from '../util';
 
@@ -45,7 +42,7 @@ export const CoverageReportCommand = baseCommand() //
     .action(generateCoverageReport);
 
 /**
- * Generates and aggregates an 'nyc' coverage report for pnpm/yarn mono repositories.
+ * Generates and aggregates an 'nyc' coverage report for a pnpm mono repository.
  * First, individual reports for each package are generated. Then, they are aggregated into one combined HTML report.
  * @param options configuration options
  */
@@ -59,8 +56,7 @@ export async function generateCoverageReport(options: CoverageCmdOptions): Promi
 }
 
 export function validateAndRetrievePackages(options: CoverageCmdOptions): PackageHelper[] {
-    const pm = detectPackageManager(options.projectRoot);
-    exec(execBinCommand(pm, 'nyc -h'), { silent: true, errorMsg: 'Nyc is not installed!' });
+    exec('pnpm exec nyc -h', { silent: true, errorMsg: 'Nyc is not installed!' });
 
     const workspacePackages = getWorkspacePackages(options.projectRoot, true);
 
@@ -75,7 +71,7 @@ export function validateAndRetrievePackages(options: CoverageCmdOptions): Packag
 
 export async function collectPackageReportFiles(packages: PackageHelper[], options: CoverageCmdOptions): Promise<string[]> {
     LOGGER.info('Create individual package coverage reports');
-    await execAsync(runScriptCommand(detectPackageManager(options.projectRoot), options.coverageScript), { silent: false });
+    await execAsync(`pnpm run ${options.coverageScript}`, { silent: false });
     const reports: string[] = packages.flatMap(pkg => findFiles(pkg.location, '**/coverage-final.json'));
     LOGGER.info(`Collected ${reports.length} coverage reports from ${packages.length} packages`);
     return reports;
@@ -106,7 +102,7 @@ async function combineReports(reportFiles: string[], options: CoverageCmdOptions
     });
 
     // Generate report
-    await execAsync(execBinCommand(detectPackageManager(options.projectRoot), 'nyc report --reporter html'), { silent: false });
+    await execAsync('pnpm exec nyc report --reporter html', { silent: false });
 
     // Restore nyc configs (if any)
     tempFiles.forEach(config => moveFile(config, config.substring(1)));

--- a/dev-packages/cli/src/commands/releng/prepare.ts
+++ b/dev-packages/cli/src/commands/releng/prepare.ts
@@ -24,14 +24,11 @@ import {
     commitChanges,
     createBranch,
     deleteFile,
-    detectPackageManager,
     exec,
     execAsync,
     getDefaultBranch,
     getWorkspacePackages,
-    installCommand,
     replaceInFile,
-    runScriptCommand,
     validateGitDirectory,
     writeFile
 } from '../../util';
@@ -156,13 +153,10 @@ async function build(options: PrepareReleaseOptions): Promise<void> {
 }
 
 async function buildNpm(options: PrepareReleaseOptions): Promise<void> {
-    const pm = detectPackageManager(options.repoDir);
-    LOGGER.info(`Install & Build with ${pm}`);
-    await execAsync(installCommand(pm), { silent: false, cwd: options.repoDir, errorMsg: `${pm} install failed` });
-    if (pm === 'pnpm') {
-        // bare `yarn` triggers the root prepare/build script implicitly; with pnpm we build explicitly
-        await execAsync(runScriptCommand(pm, '--if-present build'), { silent: false, cwd: options.repoDir, errorMsg: 'Build failed' });
-    }
+    LOGGER.info('Install & Build with pnpm');
+    await execAsync('pnpm install', { silent: false, cwd: options.repoDir, errorMsg: 'pnpm install failed' });
+    // `pnpm install` does not run the build automatically, so build explicitly.
+    await execAsync('pnpm run --if-present build', { silent: false, cwd: options.repoDir, errorMsg: 'Build failed' });
     LOGGER.debug('Build succeeded');
 }
 
@@ -185,8 +179,11 @@ async function buildJavaServer(options: PrepareReleaseOptions): Promise<void> {
 }
 
 async function buildEclipseIntegration(options: PrepareReleaseOptions): Promise<void> {
-    LOGGER.info('[Client] Install & Build with yarn');
-    // await execAsync('yarn', { silent: false, cwd: path.resolve(options.repoDir, 'client'), errorMsg: 'Client build failed' });
+    const clientDir = path.resolve(options.repoDir, 'client');
+    LOGGER.info('[Client] Install & Build with pnpm');
+    await execAsync('pnpm install', { silent: false, cwd: clientDir, errorMsg: 'Client install failed' });
+    // `pnpm install` does not run the build automatically, so build explicitly.
+    await execAsync('pnpm run --if-present build', { silent: false, cwd: clientDir, errorMsg: 'Client build failed' });
     LOGGER.newLine();
     LOGGER.info('Build Server(P2)');
     await execAsync('mvn clean install -B', {

--- a/dev-packages/cli/src/commands/releng/publish.spec.ts
+++ b/dev-packages/cli/src/commands/releng/publish.spec.ts
@@ -46,14 +46,6 @@ describe('releng publish', () => {
         fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'parent', version, private: true }));
     }
 
-    function markAsPnpmRepo(): void {
-        fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
-    }
-
-    function markAsYarnRepo(): void {
-        fs.writeFileSync(path.join(tempDir, 'yarn.lock'), '');
-    }
-
     function createPackage(relativePath: string, content: Partial<PackageData> & { name: string; version: string }): PackageHelper {
         const pkgDir = path.join(tempDir, relativePath);
         fs.mkdirSync(pkgDir, { recursive: true });
@@ -86,58 +78,9 @@ describe('releng publish', () => {
         });
     });
 
-    describe('publish (yarn/lerna fallback)', () => {
-        it('should fall back to `lerna publish ... --canary` for next on yarn repositories', async () => {
-            createRootPackage('2.8.0-next');
-            markAsYarnRepo();
-
-            await publish('next', makeOptions());
-
-            expect(execAsyncStub.calledOnce).to.be.true;
-            const cmd = execAsyncStub.firstCall.args[0] as string;
-            expect(cmd).to.equal(
-                'yarn lerna publish preminor --exact --canary --preid next --dist-tag next ' +
-                    '--no-git-tag-version --no-push --ignore-scripts --yes'
-            );
-            expect(execAsyncStub.firstCall.args[1].cwd).to.equal(tempDir);
-        });
-
-        it('should fall back to `lerna publish from-package` for latest on yarn repositories', async () => {
-            createRootPackage('2.9.0');
-            markAsYarnRepo();
-
-            await publish('latest', makeOptions());
-
-            expect(execAsyncStub.calledOnce).to.be.true;
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn lerna publish from-package --no-git-reset -y');
-        });
-
-        it('should append a custom registry to the lerna command', async () => {
-            createRootPackage('2.9.0');
-            markAsYarnRepo();
-
-            await publish('latest', makeOptions({ registry: 'http://localhost:4873' }));
-
-            expect(execAsyncStub.firstCall.args[0]).to.contain('--registry http://localhost:4873');
-        });
-
-        it('should reject --dry-run for yarn/lerna repositories', async () => {
-            createRootPackage('2.8.0-next');
-            markAsYarnRepo();
-            try {
-                await publish('next', makeOptions({ dryRun: true }));
-                expect.fail('should have thrown');
-            } catch (error) {
-                expect((error as Error).message).to.contain('only supported for pnpm-based repositories');
-            }
-            expect(execAsyncStub.notCalled).to.be.true;
-        });
-    });
-
     describe('publish next', () => {
         it('should apply the canary version to all workspace packages and publish with --tag next', async () => {
             createRootPackage('2.8.0-next');
-            markAsPnpmRepo();
             stubGit('v2.7.0', '42');
             const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', version: '2.8.0-next' });
             const pkgB = createPackage('packages/b', { name: '@eclipse-glsp/b', version: '2.8.0-next' });
@@ -160,7 +103,6 @@ describe('releng publish', () => {
 
         it('should not write versions and pass --dry-run in dry-run mode', async () => {
             createRootPackage('2.8.0-next');
-            markAsPnpmRepo();
             stubGit('v2.7.0', '7');
             const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', version: '2.8.0-next' });
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
@@ -174,7 +116,6 @@ describe('releng publish', () => {
 
         it('should pass a custom registry to pnpm publish', async () => {
             createRootPackage('2.8.0-next');
-            markAsPnpmRepo();
             stubGit('v2.7.0', '7');
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([]);
 
@@ -185,7 +126,6 @@ describe('releng publish', () => {
 
         it('should refuse to publish a canary if the root version is not a next version', async () => {
             createRootPackage('2.8.0');
-            markAsPnpmRepo();
             stubGit('v2.7.0', '7');
             try {
                 await publish('next', makeOptions());
@@ -199,7 +139,6 @@ describe('releng publish', () => {
     describe('publish latest', () => {
         it('should refuse to publish next versions under the latest dist-tag', async () => {
             createRootPackage('2.8.0-next');
-            markAsPnpmRepo();
             try {
                 await publish('latest', makeOptions());
                 expect.fail('should have thrown');
@@ -210,7 +149,6 @@ describe('releng publish', () => {
 
         it('should publish with --tag latest when unpublished packages exist', async () => {
             createRootPackage('2.9.0');
-            markAsPnpmRepo();
             const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', version: '2.9.0' });
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
             // npm view fails -> version does not exist yet
@@ -224,7 +162,6 @@ describe('releng publish', () => {
 
         it('should skip publishing when all package versions already exist', async () => {
             createRootPackage('2.9.0');
-            markAsPnpmRepo();
             const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', version: '2.9.0' });
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
             // npm view returns the version -> already published
@@ -237,7 +174,6 @@ describe('releng publish', () => {
 
         it('should ignore private packages when checking for unpublished versions', async () => {
             createRootPackage('2.9.0');
-            markAsPnpmRepo();
             const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', version: '2.9.0' });
             const examplePkg = createPackage('examples/e', { name: '@eclipse-glsp-examples/e', version: '2.9.0', private: true });
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA, examplePkg]);
@@ -253,7 +189,6 @@ describe('releng publish', () => {
     describe('publish summary', () => {
         it('should report and remove the pnpm publish summary', async () => {
             createRootPackage('2.8.0-next');
-            markAsPnpmRepo();
             stubGit('v2.7.0', '7');
             sandbox.stub(packageUtil, 'getWorkspacePackages').returns([]);
             const summaryPath = path.join(tempDir, 'pnpm-publish-summary.json');

--- a/dev-packages/cli/src/commands/releng/publish.ts
+++ b/dev-packages/cli/src/commands/releng/publish.ts
@@ -17,16 +17,7 @@
 import { Argument } from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
-import {
-    LOGGER,
-    PackageManager,
-    baseCommand,
-    detectPackageManager,
-    execAsync,
-    execBinCommand,
-    getWorkspacePackages,
-    validateGitDirectory
-} from '../../util';
+import { LOGGER, baseCommand, execAsync, getWorkspacePackages, validateGitDirectory } from '../../util';
 import { configureEnv, deriveCanaryVersion, getVersionFromPackage, isNextVersion, npmVersionExists } from './common';
 
 export type PublishDistTag = 'next' | 'latest';
@@ -40,7 +31,7 @@ export interface PublishCmdOptions {
 
 export const PublishCommand = baseCommand()
     .name('publish')
-    .description('Publish all workspace packages of a GLSP repository (pnpm: `pnpm publish`, yarn/lerna: `lerna publish`)')
+    .description('Publish all workspace packages of a GLSP repository via `pnpm publish`')
     .addArgument(new Argument('<distTag>', 'The npm dist-tag to publish under').choices(['next', 'latest']))
     .option('-v, --verbose', 'Enable verbose (debug) log output', false)
     .option('-r, --repoDir <repoDir>', 'Path to the component repository', validateGitDirectory, process.cwd())
@@ -52,49 +43,20 @@ export const PublishCommand = baseCommand()
     });
 
 /**
- * Publishes all (public) workspace packages of a GLSP repository, dispatching on the detected
- * package manager so that pnpm-based and not-yet-migrated yarn/lerna-based repositories are both
- * supported during the migration period.
+ * Publishes all (public) workspace packages of a GLSP repository via `pnpm publish -r` (so that
+ * `workspace:` ranges are rewritten to exact versions); npm provenance/trusted publishing (configured
+ * via environment) is preserved.
  * - `next`: applies a canary version (`<root-version>.<commits-since-last-tag>`) and publishes it
  *    under the `next` dist-tag.
  * - `latest`: publishes the current package versions under the `latest` dist-tag. Already published
  *    versions are skipped.
- *
- * For pnpm repositories publishing is delegated to `pnpm publish -r` (so that `workspace:` ranges are
- * rewritten to exact versions); for yarn/lerna repositories it falls back to the legacy `lerna publish`.
- * In both cases npm provenance/trusted publishing (configured via environment) is preserved.
  */
 export async function publish(distTag: PublishDistTag, options: PublishCmdOptions): Promise<void> {
-    const packageManager = detectPackageManager(options.repoDir);
-    LOGGER.info(`Publish workspace packages of '${options.repoDir}' with dist-tag '${distTag}' (package manager: ${packageManager})`);
-    if (packageManager !== 'pnpm') {
-        return publishWithLerna(distTag, packageManager, options);
-    }
+    LOGGER.info(`Publish workspace packages of '${options.repoDir}' with dist-tag '${distTag}'`);
     if (distTag === 'next') {
         return publishNext(options);
     }
     return publishLatest(options);
-}
-
-/**
- * Legacy publishing path for yarn/lerna-based repositories that have not been migrated to pnpm yet.
- * Mirrors the former root `package.json` `publish:next`/`publish:latest` scripts; `lerna` itself derives
- * the canary version (for `next`) and skips already-published versions (for `latest`). The `lerna` binary
- * is resolved from the repository's `node_modules` via the detected package manager.
- */
-async function publishWithLerna(distTag: PublishDistTag, packageManager: PackageManager, options: PublishCmdOptions): Promise<void> {
-    if (options.dryRun) {
-        throw new Error("'--dry-run' is only supported for pnpm-based repositories ('lerna publish' has no dry-run mode).");
-    }
-    const lernaArgs =
-        distTag === 'next'
-            ? 'publish preminor --exact --canary --preid next --dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes'
-            : 'publish from-package --no-git-reset -y';
-    let cmd = `${execBinCommand(packageManager, 'lerna')} ${lernaArgs}`;
-    if (options.registry) {
-        cmd += ` --registry ${options.registry}`;
-    }
-    await execAsync(cmd, { cwd: options.repoDir, silent: false, errorMsg: 'lerna publish failed' });
 }
 
 async function publishNext(options: PublishCmdOptions): Promise<void> {

--- a/dev-packages/cli/src/commands/releng/version.spec.ts
+++ b/dev-packages/cli/src/commands/releng/version.spec.ts
@@ -119,24 +119,4 @@ describe('releng version', () => {
 
         expect(readPackageJson('packages/a').dependencies!['@eclipse-glsp/protocol']).to.equal('2.9.0');
     });
-
-    it('should update lerna.json if present', async () => {
-        const root = createPackage('.', { name: 'parent', private: true });
-        fs.writeFileSync(path.join(tempDir, 'lerna.json'), JSON.stringify({ version: '2.8.0-next', npmClient: 'yarn' }));
-
-        await setVersion(makeOptions('2.9.0', [root]));
-
-        const lernaJson = JSON.parse(fs.readFileSync(path.join(tempDir, 'lerna.json'), 'utf8'));
-        expect(lernaJson.version).to.equal('2.9.0');
-        expect(lernaJson.npmClient).to.equal('yarn');
-    });
-
-    it('should succeed without lerna.json (pnpm repos)', async () => {
-        const root = createPackage('.', { name: 'parent', private: true });
-
-        await setVersion(makeOptions('2.9.0', [root]));
-
-        expect(fs.existsSync(path.join(tempDir, 'lerna.json'))).to.be.false;
-        expect(readPackageJson('.').version).to.equal('2.9.0');
-    });
 });

--- a/dev-packages/cli/src/commands/releng/version.ts
+++ b/dev-packages/cli/src/commands/releng/version.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { Argument } from 'commander';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
 import {
@@ -28,10 +27,8 @@ import {
     findFiles,
     getWorkspacePackages,
     readFile,
-    readJson,
     replaceInFile,
-    validateGitDirectory,
-    writeJson
+    validateGitDirectory
 } from '../../util';
 import { GLSPRepo, RelengCmdOptions, RelengOptions, VersionType, asMvnVersion, configureEnv, isNextVersion } from './common';
 interface SetVersionsCmdOptions extends RelengCmdOptions {}
@@ -102,16 +99,6 @@ function setVersionNpm(options: NpmSetVersionOptions): void {
 
         pkg.write();
     });
-
-    // Update lerna file if present (repos migrated to pnpm no longer have one — the root package.json is the source of truth)
-    const lernaJsonPath = path.resolve(options.repoDir, 'lerna.json');
-    if (fs.existsSync(lernaJsonPath)) {
-        const lernaJson = readJson<{ version: string }>(lernaJsonPath);
-        lernaJson.version = options.version;
-        writeJson(lernaJsonPath, lernaJson);
-    } else {
-        LOGGER.debug('No lerna.json found, skipping update');
-    }
 
     // Repo specific changes
     if (options.repo === 'glsp-theia-integration') {

--- a/dev-packages/cli/src/commands/repo/build.spec.ts
+++ b/dev-packages/cli/src/commands/repo/build.spec.ts
@@ -43,14 +43,6 @@ describe('build-action', () => {
         }
     }
 
-    function markAsYarnRepo(name: string): void {
-        fs.writeFileSync(path.join(tempDir, name, 'yarn.lock'), '');
-    }
-
-    function markAsPnpmRepo(name: string): void {
-        fs.writeFileSync(path.join(tempDir, name, 'pnpm-workspace.yaml'), '');
-    }
-
     beforeEach(() => {
         tempDir = createTempDir();
         execAsyncStub = sandbox.stub(processUtil, 'execAsync').resolves('');
@@ -62,35 +54,16 @@ describe('build-action', () => {
     });
 
     describe('buildSingleRepo', () => {
-        it('should run yarn install for standard yarn repos', async () => {
+        it('should run pnpm install and explicit build for standard repos', async () => {
             createRepoDirs('glsp-client');
-            markAsYarnRepo('glsp-client');
-            await buildSingleRepo('glsp-client', makeOptions());
-            expect(execAsyncStub.calledOnce).to.be.true;
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
-        });
-
-        it('should run pnpm install and explicit build for standard pnpm repos', async () => {
-            createRepoDirs('glsp-client');
-            markAsPnpmRepo('glsp-client');
             await buildSingleRepo('glsp-client', makeOptions());
             expect(execAsyncStub.callCount).to.equal(2);
             expect(execAsyncStub.firstCall.args[0]).to.equal('pnpm install');
             expect(execAsyncStub.secondCall.args[0]).to.equal('pnpm run --if-present build');
         });
 
-        it('should run yarn install then yarn browser build for theia-integration (yarn)', async () => {
+        it('should run pnpm install, build and browser build for theia-integration', async () => {
             createRepoDirs('glsp-theia-integration');
-            markAsYarnRepo('glsp-theia-integration');
-            await buildSingleRepo('glsp-theia-integration', makeOptions());
-            expect(execAsyncStub.callCount).to.equal(2);
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
-            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn browser build');
-        });
-
-        it('should run pnpm install, build and browser build for theia-integration (pnpm)', async () => {
-            createRepoDirs('glsp-theia-integration');
-            markAsPnpmRepo('glsp-theia-integration');
             await buildSingleRepo('glsp-theia-integration', makeOptions());
             expect(execAsyncStub.callCount).to.equal(3);
             expect(execAsyncStub.firstCall.args[0]).to.equal('pnpm install');
@@ -98,12 +71,11 @@ describe('build-action', () => {
             expect(execAsyncStub.thirdCall.args[0]).to.equal('pnpm run browser build');
         });
 
-        it('should run yarn electron build with --electron', async () => {
+        it('should run electron build with --electron', async () => {
             createRepoDirs('glsp-theia-integration');
-            markAsYarnRepo('glsp-theia-integration');
             await buildSingleRepo('glsp-theia-integration', makeOptions({ electron: true }));
-            expect(execAsyncStub.callCount).to.equal(2);
-            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn electron build');
+            expect(execAsyncStub.callCount).to.equal(3);
+            expect(execAsyncStub.thirdCall.args[0]).to.equal('pnpm run electron build');
         });
 
         it('should run mvn for glsp-server', async () => {
@@ -115,23 +87,24 @@ describe('build-action', () => {
 
         it('should build client and server for eclipse-integration', async () => {
             createRepoDirs(path.join('glsp-eclipse-integration', 'client'));
-            markAsYarnRepo(path.join('glsp-eclipse-integration', 'client'));
             await buildSingleRepo('glsp-eclipse-integration', makeOptions());
-            expect(execAsyncStub.callCount).to.equal(2);
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
+            expect(execAsyncStub.callCount).to.equal(3);
+            expect(execAsyncStub.firstCall.args[0]).to.equal('pnpm install');
             expect(execAsyncStub.firstCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
-            expect(execAsyncStub.secondCall.args[0]).to.equal('mvn clean verify -Dstyle.color=always -B');
-            expect(execAsyncStub.secondCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'server'));
+            expect(execAsyncStub.secondCall.args[0]).to.equal('pnpm run --if-present build');
+            expect(execAsyncStub.secondCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
+            expect(execAsyncStub.thirdCall.args[0]).to.equal('mvn clean verify -Dstyle.color=always -B');
+            expect(execAsyncStub.thirdCall.args[1].cwd).to.contain(path.join('glsp-eclipse-integration', 'server'));
         });
     });
 
     describe('runBuildOrdered', () => {
         it('should build repos sequentially in dependency order', async () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
-            ['glsp', 'glsp-client', 'glsp-server-node'].forEach(markAsYarnRepo);
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions());
             expect(failures).to.equal(0);
-            expect(execAsyncStub.callCount).to.equal(3);
+            // pnpm install + build per repo
+            expect(execAsyncStub.callCount).to.equal(6);
         });
 
         it('should error if a repo directory is missing', async () => {
@@ -146,7 +119,6 @@ describe('build-action', () => {
 
         it('should stop on first failure when failFast is true', async () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
-            ['glsp', 'glsp-client', 'glsp-server-node'].forEach(markAsYarnRepo);
             execAsyncStub.onFirstCall().rejects(new Error('build failed'));
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: true }));
             expect(failures).to.equal(1);
@@ -155,11 +127,11 @@ describe('build-action', () => {
 
         it('should continue on failure when failFast is false', async () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
-            ['glsp', 'glsp-client', 'glsp-server-node'].forEach(markAsYarnRepo);
             execAsyncStub.onFirstCall().rejects(new Error('build failed'));
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: false }));
             expect(failures).to.equal(1);
-            expect(execAsyncStub.callCount).to.equal(3);
+            // first repo fails on install (1 call); the other two each run install + build (2+2)
+            expect(execAsyncStub.callCount).to.equal(5);
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/build.ts
+++ b/dev-packages/cli/src/commands/repo/build.ts
@@ -16,7 +16,7 @@
 
 import { Command, Option } from 'commander';
 import * as path from 'path';
-import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, detectPackageManager, execAsync, installCommand, runScriptCommand } from '../../util';
+import { GLSPRepo, LOGGER, PRESET_NAMES, baseCommand, execAsync } from '../../util';
 import { configureRepoEnv, formatError, getBuildOrder, resolveTargetRepos, resolveWorkspaceDir, validateReposExist } from './common/utils';
 
 // ── Action ──────────────────────────────────────────────────────────────────
@@ -26,47 +26,70 @@ export interface BuildActionOptions {
     electron: boolean;
     verbose: boolean;
     failFast: boolean;
+    /** Run `pnpm install` before building. Default `true`; the link flow sets `false` (already installed). */
+    install?: boolean;
+    /** Build the Java/Maven parts (eclipse server, glsp-server). Default `true`; the link flow skips them. */
+    java?: boolean;
 }
 
-async function installAndBuildNpm(repoDir: string, execOpts: { cwd?: string; verbose: boolean; silent: boolean }): Promise<void> {
-    const pm = detectPackageManager(repoDir);
-    LOGGER.debug(`${pm} install`);
-    await execAsync(installCommand(pm), { ...execOpts, cwd: repoDir });
-    if (pm === 'pnpm') {
-        // bare `yarn` triggers the root prepare/build script implicitly; with pnpm we build explicitly
-        LOGGER.debug('pnpm build');
-        await execAsync(runScriptCommand(pm, '--if-present build'), { ...execOpts, cwd: repoDir });
+interface NpmExecOpts {
+    cwd?: string;
+    verbose: boolean;
+    silent: boolean;
+}
+
+async function installNpm(repoDir: string, execOpts: NpmExecOpts): Promise<void> {
+    LOGGER.debug('pnpm install');
+    await execAsync('pnpm install', { ...execOpts, cwd: repoDir });
+}
+
+// `pnpm install` does not run the build automatically, so build explicitly.
+async function buildNpm(repoDir: string, execOpts: NpmExecOpts): Promise<void> {
+    LOGGER.debug('pnpm build');
+    await execAsync('pnpm run --if-present build', { ...execOpts, cwd: repoDir });
+}
+
+async function installAndBuildNpm(repoDir: string, execOpts: NpmExecOpts, install: boolean): Promise<void> {
+    if (install) {
+        await installNpm(repoDir, execOpts);
     }
+    await buildNpm(repoDir, execOpts);
 }
 
 export async function buildSingleRepo(repo: GLSPRepo, options: BuildActionOptions): Promise<void> {
     const repoDir = path.resolve(options.dir, repo);
     const npmOpts = { cwd: repoDir, verbose: options.verbose, silent: false, env: { FORCE_COLOR: '1' } };
     const mvnOpts = { cwd: repoDir, verbose: options.verbose, silent: false };
+    const install = options.install ?? true;
+    const java = options.java ?? true;
 
     LOGGER.label(`Building ${repo}...`);
 
     switch (repo) {
         case 'glsp-theia-integration': {
-            await installAndBuildNpm(repoDir, npmOpts);
+            await installAndBuildNpm(repoDir, npmOpts, install);
             const target = options.electron ? 'electron' : 'browser';
             LOGGER.debug('Build for target: ' + target);
-            await execAsync(runScriptCommand(detectPackageManager(repoDir), `${target} build`), npmOpts);
+            await execAsync(`pnpm run ${target} build`, npmOpts);
             break;
         }
         case 'glsp-server': {
-            await execAsync('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B', mvnOpts);
+            if (java) {
+                await execAsync('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B', mvnOpts);
+            }
             break;
         }
         case 'glsp-eclipse-integration': {
             LOGGER.debug('Build client');
-            await installAndBuildNpm(path.join(repoDir, 'client'), npmOpts);
-            LOGGER.debug('Maven build for server');
-            await execAsync('mvn clean verify -Dstyle.color=always -B', { ...mvnOpts, cwd: path.join(repoDir, 'server') });
+            await installAndBuildNpm(path.join(repoDir, 'client'), npmOpts, install);
+            if (java) {
+                LOGGER.debug('Maven build for server');
+                await execAsync('mvn clean verify -Dstyle.color=always -B', { ...mvnOpts, cwd: path.join(repoDir, 'server') });
+            }
             break;
         }
         default: {
-            await installAndBuildNpm(repoDir, npmOpts);
+            await installAndBuildNpm(repoDir, npmOpts, install);
             break;
         }
     }

--- a/dev-packages/cli/src/commands/repo/link.spec.ts
+++ b/dev-packages/cli/src/commands/repo/link.spec.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as sinon from 'sinon';
+import * as YAML from 'yaml';
 import { GLSPRepo, PackageHelper } from '../../util';
 import * as packageUtil from '../../util/package-util';
 import * as processUtil from '../../util/process-util';
@@ -25,38 +26,36 @@ import { cleanupTempDir, createTempDir } from '../../../tests/helpers/test-helpe
 import {
     SINGLETON_DEPS,
     LinkActionOptions,
+    applyLinkOverrides,
+    collectProvidedPackages,
+    collectSingletonLinks,
     filterLinkableRepos,
     getGLSPWorkspacePackages,
-    getRegisteredPackages,
-    registerPackages,
-    registerSingletons,
-    consumePackages,
-    consumeSingletons,
+    removeLinkOverrides,
+    resolveSingletonDir,
     runLink,
     runUnlink
 } from './link';
 
-function mockPkg(name: string, location: string, deps: Record<string, string> = {}, devDeps: Record<string, string> = {}): PackageHelper {
+function mockPkg(name: string, location: string): PackageHelper {
     return {
         name,
         location,
         filePath: path.join(location, 'package.json'),
-        content: { name, version: '1.0.0', dependencies: deps, devDependencies: devDeps }
+        content: { name, version: '1.0.0' }
     } as unknown as PackageHelper;
 }
 
 describe('link-action', () => {
     const sandbox = sinon.createSandbox();
     let tempDir: string;
-    let execStub: sinon.SinonStub;
     let execAsyncStub: sinon.SinonStub;
     let workspaceStub: sinon.SinonStub;
 
     beforeEach(() => {
         tempDir = createTempDir();
-        execStub = sandbox.stub(processUtil, 'exec').returns('');
         execAsyncStub = sandbox.stub(processUtil, 'execAsync').resolves('');
-        workspaceStub = sandbox.stub(packageUtil, 'getYarnWorkspacePackages');
+        workspaceStub = sandbox.stub(packageUtil, 'getWorkspacePackages');
         workspaceStub.returns([]);
     });
 
@@ -71,10 +70,28 @@ describe('link-action', () => {
         }
     }
 
+    /** Creates resolvable node_modules packages (real package.json + entry) so `require.resolve` finds them. */
     function createNodeModules(repo: string, ...deps: string[]): void {
         for (const dep of deps) {
-            fs.mkdirSync(path.join(tempDir, repo, 'node_modules', dep), { recursive: true });
+            const depDir = path.join(tempDir, repo, 'node_modules', dep);
+            fs.mkdirSync(depDir, { recursive: true });
+            fs.writeFileSync(path.join(depDir, 'package.json'), JSON.stringify({ name: dep, version: '1.0.0', main: 'index.js' }));
+            fs.writeFileSync(path.join(depDir, 'index.js'), 'module.exports = {};');
         }
+        // createRequire needs an anchor manifest in the repo dir
+        const repoManifest = path.join(tempDir, repo, 'package.json');
+        if (!fs.existsSync(repoManifest)) {
+            fs.writeFileSync(repoManifest, JSON.stringify({ name: repo, version: '1.0.0' }));
+        }
+    }
+
+    function writeWorkspaceYaml(repo: string, content: Record<string, unknown>): void {
+        fs.writeFileSync(path.join(tempDir, repo, 'pnpm-workspace.yaml'), YAML.stringify(content));
+    }
+
+    function readWorkspaceYaml(repo: string): { packages?: string[]; overrides?: Record<string, string> } {
+        const yamlPath = path.join(tempDir, repo, 'pnpm-workspace.yaml');
+        return fs.existsSync(yamlPath) ? YAML.parse(fs.readFileSync(yamlPath, 'utf8')) : {};
     }
 
     function makeOptions(overrides: Partial<LinkActionOptions> = {}): LinkActionOptions {
@@ -84,20 +101,16 @@ describe('link-action', () => {
     function setupWorkspaceStub(): void {
         const clientPkg = mockPkg('@eclipse-glsp/client', path.join(tempDir, 'glsp-client/packages/client'));
         const protocolPkg = mockPkg('@eclipse-glsp/protocol', path.join(tempDir, 'glsp-client/packages/protocol'));
-        const serverPkg = mockPkg('@eclipse-glsp/server', path.join(tempDir, 'glsp-server-node/packages/server'), {
-            '@eclipse-glsp/protocol': '^1.0.0'
-        });
-        workspaceStub.callsFake((rootPath: string, includeRoot?: boolean) => {
+        const serverPkg = mockPkg('@eclipse-glsp/server', path.join(tempDir, 'glsp-server-node/packages/server'));
+        workspaceStub.callsFake((rootPath: string) => {
             const repoName = path.basename(rootPath);
-            let packages: PackageHelper[];
             if (repoName === 'glsp-client') {
-                packages = [clientPkg, protocolPkg];
-            } else if (repoName === 'glsp-server-node') {
-                packages = [serverPkg];
-            } else {
-                packages = [];
+                return [clientPkg, protocolPkg];
             }
-            return includeRoot ? [mockPkg(repoName, rootPath), ...packages] : packages;
+            if (repoName === 'glsp-server-node') {
+                return [serverPkg];
+            }
+            return [];
         });
     }
 
@@ -107,93 +120,14 @@ describe('link-action', () => {
             expect(result).to.deep.equal(['glsp-client', 'glsp-server-node', 'glsp-theia-integration']);
         });
 
+        it('should keep glsp-eclipse-integration', () => {
+            const result = filterLinkableRepos(['glsp-client', 'glsp-eclipse-integration'] as GLSPRepo[]);
+            expect(result).to.deep.equal(['glsp-client', 'glsp-eclipse-integration']);
+        });
+
         it('should exclude non-linkable repos', () => {
-            const result = filterLinkableRepos(['glsp-client', 'glsp-server', 'glsp-eclipse-integration', 'glsp-playwright'] as GLSPRepo[]);
+            const result = filterLinkableRepos(['glsp-client', 'glsp-server', 'glsp-playwright'] as GLSPRepo[]);
             expect(result).to.deep.equal(['glsp-client']);
-        });
-    });
-
-    describe('getRegisteredPackages', () => {
-        it('should return scoped packages from the link directory', () => {
-            const linkDir = path.join(tempDir, '.yarn-link');
-            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'client'), { recursive: true });
-            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'protocol'), { recursive: true });
-            const result = getRegisteredPackages(linkDir);
-            expect(result).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
-        });
-
-        it('should return empty array when link directory does not exist', () => {
-            const result = getRegisteredPackages(path.join(tempDir, 'nonexistent'));
-            expect(result).to.deep.equal([]);
-        });
-
-        it('should ignore non-scoped entries', () => {
-            const linkDir = path.join(tempDir, '.yarn-link');
-            fs.mkdirSync(path.join(linkDir, '@eclipse-glsp', 'client'), { recursive: true });
-            fs.writeFileSync(path.join(linkDir, 'sprotty'), '');
-            const result = getRegisteredPackages(linkDir);
-            expect(result).to.deep.equal(['@eclipse-glsp/client']);
-        });
-    });
-
-    describe('registerPackages', () => {
-        it('should run yarn link for each @eclipse-glsp workspace package and return names', () => {
-            const repoDir = path.join(tempDir, 'glsp-client');
-            const linkDir = path.join(tempDir, '.yarn-link');
-            workspaceStub
-                .withArgs(repoDir)
-                .returns([
-                    mockPkg('@eclipse-glsp/client', path.join(repoDir, 'packages/client')),
-                    mockPkg('@eclipse-glsp/protocol', path.join(repoDir, 'packages/protocol'))
-                ]);
-            const registered = registerPackages(repoDir, linkDir);
-            expect(registered).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
-            expect(execStub.callCount).to.equal(2);
-            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir}`);
-            expect(execStub.firstCall.args[1].cwd).to.equal(path.join(repoDir, 'packages/client'));
-            expect(execStub.secondCall.args[1].cwd).to.equal(path.join(repoDir, 'packages/protocol'));
-        });
-    });
-
-    describe('registerSingletons', () => {
-        it('should run yarn link for each singleton in node_modules', () => {
-            const clientDir = path.join(tempDir, 'glsp-client');
-            const linkDir = path.join(tempDir, '.yarn-link');
-            registerSingletons(clientDir, linkDir);
-            expect(execStub.callCount).to.equal(SINGLETON_DEPS.length);
-            for (let i = 0; i < SINGLETON_DEPS.length; i++) {
-                expect(execStub.getCall(i).args[0]).to.equal(`yarn link --link-folder ${linkDir}`);
-                expect(execStub.getCall(i).args[1].cwd).to.equal(path.join(clientDir, 'node_modules', SINGLETON_DEPS[i]));
-            }
-        });
-    });
-
-    describe('consumePackages', () => {
-        it('should link all registered packages into the repo', () => {
-            const repoDir = path.join(tempDir, 'glsp-server-node');
-            const linkDir = path.join(tempDir, '.yarn-link');
-            consumePackages(repoDir, linkDir, ['@eclipse-glsp/protocol', '@eclipse-glsp/client']);
-            expect(execStub.calledOnce).to.be.true;
-            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir} @eclipse-glsp/protocol @eclipse-glsp/client`);
-            expect(execStub.firstCall.args[1].cwd).to.equal(repoDir);
-        });
-
-        it('should not call exec when registeredPackages is empty', () => {
-            const repoDir = path.join(tempDir, 'glsp-server-node');
-            const linkDir = path.join(tempDir, '.yarn-link');
-            consumePackages(repoDir, linkDir, []);
-            expect(execStub.called).to.be.false;
-        });
-    });
-
-    describe('consumeSingletons', () => {
-        it('should link all singleton deps', () => {
-            const repoDir = path.join(tempDir, 'glsp-server-node');
-            const linkDir = path.join(tempDir, '.yarn-link');
-            consumeSingletons(repoDir, linkDir);
-            expect(execStub.calledOnce).to.be.true;
-            expect(execStub.firstCall.args[0]).to.equal(`yarn link --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`);
-            expect(execStub.firstCall.args[1].cwd).to.equal(repoDir);
         });
     });
 
@@ -213,151 +147,252 @@ describe('link-action', () => {
         });
     });
 
+    describe('collectProvidedPackages', () => {
+        it('should map @eclipse-glsp workspace packages to their location', () => {
+            const repoDir = path.join(tempDir, 'glsp-client');
+            workspaceStub
+                .withArgs(repoDir)
+                .returns([
+                    mockPkg('@eclipse-glsp/client', path.join(repoDir, 'packages/client')),
+                    mockPkg('@eclipse-glsp/protocol', path.join(repoDir, 'packages/protocol'))
+                ]);
+            expect(collectProvidedPackages(repoDir)).to.deep.equal({
+                '@eclipse-glsp/client': path.join(repoDir, 'packages/client'),
+                '@eclipse-glsp/protocol': path.join(repoDir, 'packages/protocol')
+            });
+        });
+    });
+
+    describe('resolveSingletonDir', () => {
+        it('should resolve the package directory as seen from a provider dir', () => {
+            createNodeModules('glsp-client', 'sprotty');
+            const clientDir = path.join(tempDir, 'glsp-client');
+            const dir = resolveSingletonDir([clientDir], 'sprotty');
+            expect(dir).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
+        });
+
+        it('should walk up to the package root when the entry has a nested manifest', () => {
+            const clientDir = path.join(tempDir, 'glsp-client');
+            fs.mkdirSync(clientDir, { recursive: true });
+            fs.writeFileSync(path.join(clientDir, 'package.json'), JSON.stringify({ name: 'glsp-client' }));
+            // inversify-style layout: package root + a nested lib/cjs/package.json without a name
+            const invDir = path.join(clientDir, 'node_modules', 'inversify');
+            fs.mkdirSync(path.join(invDir, 'lib', 'cjs'), { recursive: true });
+            fs.writeFileSync(path.join(invDir, 'package.json'), JSON.stringify({ name: 'inversify', main: 'lib/cjs/index.js' }));
+            fs.writeFileSync(path.join(invDir, 'lib', 'cjs', 'package.json'), JSON.stringify({ type: 'commonjs' }));
+            fs.writeFileSync(path.join(invDir, 'lib', 'cjs', 'index.js'), 'module.exports = {};');
+
+            expect(resolveSingletonDir([clientDir], 'inversify')).to.equal(fs.realpathSync(invDir));
+        });
+
+        it('should return undefined when the dependency is not resolvable from any dir', () => {
+            createRepoDirs('glsp-client');
+            fs.writeFileSync(path.join(tempDir, 'glsp-client', 'package.json'), JSON.stringify({ name: 'glsp-client' }));
+            expect(resolveSingletonDir([path.join(tempDir, 'glsp-client')], 'sprotty')).to.be.undefined;
+        });
+    });
+
+    describe('collectSingletonLinks', () => {
+        it('should collect resolvable singletons from the glsp-client install', () => {
+            workspaceStub.returns([]); // no @eclipse-glsp packages → resolve from clientDir fallback
+            createNodeModules('glsp-client', 'sprotty', 'inversify');
+            const clientDir = path.join(tempDir, 'glsp-client');
+            const links = collectSingletonLinks(clientDir);
+            expect(links.sprotty).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
+            expect(links.inversify).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'inversify')));
+            // unresolvable singletons (sprotty-protocol, etc.) are simply skipped
+            expect(links['sprotty-protocol']).to.be.undefined;
+        });
+    });
+
+    describe('applyLinkOverrides', () => {
+        it('should write relative link: overrides and preserve existing content', () => {
+            createRepoDirs('glsp-server-node');
+            writeWorkspaceYaml('glsp-server-node', { packages: ['packages/*'], overrides: { foo: '1.0.0' } });
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            applyLinkOverrides(repoDir, { '@eclipse-glsp/protocol': path.join(tempDir, 'glsp-client/packages/protocol') });
+
+            const workspace = readWorkspaceYaml('glsp-server-node');
+            expect(workspace.packages).to.deep.equal(['packages/*']);
+            expect(workspace.overrides).to.deep.equal({
+                foo: '1.0.0',
+                '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol'
+            });
+        });
+
+        it('should create the workspace file when missing', () => {
+            createRepoDirs('glsp-server-node');
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            applyLinkOverrides(repoDir, { sprotty: path.join(tempDir, 'glsp-client/node_modules/sprotty') });
+            expect(readWorkspaceYaml('glsp-server-node').overrides).to.deep.equal({ sprotty: 'link:../glsp-client/node_modules/sprotty' });
+        });
+
+        it('should be a no-op for empty links', () => {
+            createRepoDirs('glsp-server-node');
+            const repoDir = path.join(tempDir, 'glsp-server-node');
+            applyLinkOverrides(repoDir, {});
+            expect(fs.existsSync(path.join(repoDir, 'pnpm-workspace.yaml'))).to.be.false;
+        });
+    });
+
+    describe('removeLinkOverrides', () => {
+        it('should remove only managed link overrides and keep others', () => {
+            createRepoDirs('glsp-server-node');
+            writeWorkspaceYaml('glsp-server-node', {
+                packages: ['packages/*'],
+                overrides: {
+                    '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol',
+                    '@eclipse-glsp-examples/workflow-glsp': 'link:../glsp-client/examples/workflow-glsp',
+                    sprotty: 'link:../glsp-client/node_modules/sprotty',
+                    'some-dep': '1.2.3'
+                }
+            });
+            const removed = removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
+            expect(removed).to.be.true;
+            const workspace = readWorkspaceYaml('glsp-server-node');
+            expect(workspace.packages).to.deep.equal(['packages/*']);
+            expect(workspace.overrides).to.deep.equal({ 'some-dep': '1.2.3' });
+        });
+
+        it('should drop the overrides key when it becomes empty', () => {
+            createRepoDirs('glsp-server-node');
+            writeWorkspaceYaml('glsp-server-node', {
+                packages: ['packages/*'],
+                overrides: { '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol' }
+            });
+            removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
+            expect(readWorkspaceYaml('glsp-server-node')).to.not.have.property('overrides');
+        });
+
+        it('should not touch non-link overrides for the same package', () => {
+            createRepoDirs('glsp-server-node');
+            writeWorkspaceYaml('glsp-server-node', { overrides: { sprotty: '1.4.0' } });
+            const removed = removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
+            expect(removed).to.be.false;
+            expect(readWorkspaceYaml('glsp-server-node').overrides).to.deep.equal({ sprotty: '1.4.0' });
+        });
+
+        it('should return false when no workspace file exists', () => {
+            createRepoDirs('glsp-server-node');
+            expect(removeLinkOverrides(path.join(tempDir, 'glsp-server-node'))).to.be.false;
+        });
+    });
+
     describe('runLink', () => {
-        it('should register, consume, and reinstall in build order', async () => {
+        it('should link provider packages and singletons into downstream repos in build order', async () => {
             createRepoDirs('glsp-client', 'glsp-server-node');
             createNodeModules('glsp-client', ...SINGLETON_DEPS);
             setupWorkspaceStub();
 
             await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
 
-            const linkDir = path.join(tempDir, '.yarn-link');
+            // glsp-client is the source of truth and gets no overrides.
+            expect(readWorkspaceYaml('glsp-client')).to.not.have.property('overrides');
 
-            const clientRegCalls = execStub
-                .getCalls()
-                .filter(
-                    (c: sinon.SinonSpyCall) =>
-                        c.args[0] === `yarn link --link-folder ${linkDir}` && (c.args[1]?.cwd as string)?.includes('glsp-client/packages')
-                );
-            expect(clientRegCalls).to.have.length(2);
+            // glsp-server-node consumes glsp-client's packages and the shared singletons.
+            const serverOverrides = readWorkspaceYaml('glsp-server-node').overrides ?? {};
+            expect(serverOverrides['@eclipse-glsp/client']).to.equal('link:../glsp-client/packages/client');
+            expect(serverOverrides['@eclipse-glsp/protocol']).to.equal('link:../glsp-client/packages/protocol');
+            for (const dep of SINGLETON_DEPS) {
+                expect(serverOverrides[dep]).to.equal(`link:../glsp-client/node_modules/${dep}`);
+            }
 
-            const singletonRegCalls = execStub
-                .getCalls()
-                .filter(
-                    (c: sinon.SinonSpyCall) =>
-                        c.args[0] === `yarn link --link-folder ${linkDir}` &&
-                        (c.args[1]?.cwd as string)?.includes('glsp-client/node_modules')
-                );
-            expect(singletonRegCalls).to.have.length(SINGLETON_DEPS.length);
-
-            const clientConsumeCall = execStub
-                .getCalls()
-                .find(
-                    (c: sinon.SinonSpyCall) =>
-                        (c.args[0] as string).includes('@eclipse-glsp/client') && c.args[1]?.cwd === path.join(tempDir, 'glsp-client')
-                );
-            expect(clientConsumeCall).to.be.undefined;
-
-            const consumeCall = execStub
-                .getCalls()
-                .find(
-                    (c: sinon.SinonSpyCall) =>
-                        (c.args[0] as string).includes('@eclipse-glsp/client') &&
-                        (c.args[0] as string).includes('@eclipse-glsp/protocol') &&
-                        (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
-                );
-            expect(consumeCall).to.not.be.undefined;
-
-            const singletonConsumeCall = execStub
-                .getCalls()
-                .find(
-                    (c: sinon.SinonSpyCall) =>
-                        (c.args[0] as string).includes(SINGLETON_DEPS.join(' ')) && (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
-                );
-            expect(singletonConsumeCall).to.not.be.undefined;
-
-            expect(execAsyncStub.callCount).to.equal(3);
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
-            expect(execAsyncStub.secondCall.args[0]).to.equal('yarn install --force');
-            expect(execAsyncStub.thirdCall.args[0]).to.equal('yarn install --force');
+            // Each repo is installed (to apply the overrides) and then built, in build order:
+            // install client, build client, install server-node, build server-node.
+            expect(execAsyncStub.callCount).to.equal(4);
+            const calls = execAsyncStub.getCalls().map(c => [c.args[0], c.args[1].cwd] as const);
+            expect(calls).to.deep.equal([
+                ['pnpm install --no-frozen-lockfile', path.join(tempDir, 'glsp-client')],
+                ['pnpm run --if-present build', path.join(tempDir, 'glsp-client')],
+                ['pnpm install --no-frozen-lockfile', path.join(tempDir, 'glsp-server-node')],
+                ['pnpm run --if-present build', path.join(tempDir, 'glsp-server-node')]
+            ]);
         });
 
-        it('should run yarn install before registering singletons for glsp-client', async () => {
-            createRepoDirs('glsp-client');
+        it('should not build when build is disabled', async () => {
+            createRepoDirs('glsp-client', 'glsp-server-node');
+            createNodeModules('glsp-client', ...SINGLETON_DEPS);
             setupWorkspaceStub();
 
-            await runLink(['glsp-client'] as GLSPRepo[], makeOptions());
+            await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ build: false }));
 
-            expect(execAsyncStub.firstCall.args[0]).to.equal('yarn install');
-            expect(execAsyncStub.firstCall.args[1].cwd).to.equal(path.join(tempDir, 'glsp-client'));
+            // Only the override-applying install runs per repo; no build.
+            expect(execAsyncStub.callCount).to.equal(2);
+            expect(execAsyncStub.getCalls().every(c => c.args[0] === 'pnpm install --no-frozen-lockfile')).to.be.true;
+        });
+
+        it('should link into the client/ subdir for glsp-eclipse-integration', async () => {
+            createRepoDirs('glsp-client', 'glsp-eclipse-integration');
+            createNodeModules('glsp-client', ...SINGLETON_DEPS);
+            // The linkable pnpm workspace of glsp-eclipse-integration lives in client/, not the repo root.
+            const clientDir = path.join(tempDir, 'glsp-eclipse-integration', 'client');
+            fs.mkdirSync(clientDir, { recursive: true });
+            setupWorkspaceStub();
+
+            await runLink(['glsp-client', 'glsp-eclipse-integration'] as GLSPRepo[], makeOptions({ build: false }));
+
+            // Overrides go into client/pnpm-workspace.yaml, not the repo root.
+            expect(fs.existsSync(path.join(tempDir, 'glsp-eclipse-integration', 'pnpm-workspace.yaml'))).to.be.false;
+            const overrides = (YAML.parse(fs.readFileSync(path.join(clientDir, 'pnpm-workspace.yaml'), 'utf8')).overrides ?? {}) as Record<
+                string,
+                string
+            >;
+            // Relative link paths gain an extra ../ because the workspace is one level deeper than the repo root.
+            expect(overrides['@eclipse-glsp/client']).to.equal('link:../../glsp-client/packages/client');
+            for (const dep of SINGLETON_DEPS) {
+                expect(overrides[dep]).to.equal(`link:../../glsp-client/node_modules/${dep}`);
+            }
+
+            // The install runs in the client/ workspace, not the repo root.
+            const eclipseInstall = execAsyncStub.getCalls().find(c => c.args[1].cwd === clientDir);
+            expect(eclipseInstall, 'install should run in client/').to.not.be.undefined;
         });
 
         it('should stop on first failure when failFast is true', async () => {
             createRepoDirs('glsp-client', 'glsp-server-node');
-            workspaceStub.returns([]);
-            execStub.throws(new Error('link failed'));
+            setupWorkspaceStub();
+            execAsyncStub.rejects(new Error('install failed'));
             try {
                 await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
                 expect.fail('should have thrown');
             } catch (error) {
                 expect((error as Error).message).to.contain('failed to link');
             }
-        });
-
-        it('should continue on failure when failFast is false', async () => {
-            createRepoDirs('glsp-client', 'glsp-server-node');
-            createNodeModules('glsp-client', ...SINGLETON_DEPS);
-            setupWorkspaceStub();
-            execStub.onFirstCall().throws(new Error('link failed'));
-            execStub.returns('');
-
-            try {
-                await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: false }));
-                expect.fail('should have thrown');
-            } catch (error) {
-                expect((error as Error).message).to.contain('failed to link');
-            }
-            expect(execAsyncStub.called).to.be.true;
+            expect(execAsyncStub.callCount).to.equal(1);
         });
 
         it('should skip non-linkable repos', async () => {
             createRepoDirs('glsp-server');
             await runLink(['glsp-server'] as GLSPRepo[], makeOptions());
-            expect(execStub.called).to.be.false;
             expect(execAsyncStub.called).to.be.false;
         });
     });
 
     describe('runUnlink', () => {
-        function createLinkDir(...packages: string[]): void {
-            for (const pkg of packages) {
-                fs.mkdirSync(path.join(tempDir, '.yarn-link', pkg), { recursive: true });
-            }
-        }
-
-        it('should unlink repos in reverse build order', async () => {
+        it('should remove link overrides and reinstall in reverse build order', async () => {
             createRepoDirs('glsp-client', 'glsp-server-node');
-            createNodeModules('glsp-client', ...SINGLETON_DEPS);
-            createLinkDir('@eclipse-glsp/client', '@eclipse-glsp/protocol');
-            setupWorkspaceStub();
+            writeWorkspaceYaml('glsp-server-node', {
+                overrides: {
+                    '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol',
+                    sprotty: 'link:../glsp-client/node_modules/sprotty'
+                }
+            });
 
             await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
 
-            const linkDir = path.join(tempDir, '.yarn-link');
-
-            const serverUnlinks = execStub
-                .getCalls()
-                .filter(
-                    (c: sinon.SinonSpyCall) =>
-                        (c.args[0] as string).startsWith('yarn unlink') && (c.args[1]?.cwd as string)?.endsWith('glsp-server-node')
-                );
-            expect(serverUnlinks.length).to.be.greaterThan(0);
-
-            const clientUnregCalls = execStub
-                .getCalls()
-                .filter(
-                    (c: sinon.SinonSpyCall) =>
-                        c.args[0] === `yarn unlink --link-folder ${linkDir}` && (c.args[1]?.cwd as string)?.includes('glsp-client/packages')
-                );
-            expect(clientUnregCalls).to.have.length(2);
-
-            expect(execAsyncStub.callCount).to.equal(2);
+            expect(readWorkspaceYaml('glsp-server-node')).to.not.have.property('overrides');
+            // Only glsp-server-node had overrides, so only it is reinstalled.
+            expect(execAsyncStub.callCount).to.equal(1);
+            expect(execAsyncStub.firstCall.args[0]).to.equal('pnpm install --no-frozen-lockfile');
+            expect(execAsyncStub.firstCall.args[1].cwd).to.equal(path.join(tempDir, 'glsp-server-node'));
         });
 
         it('should stop on first failure when failFast is true', async () => {
             createRepoDirs('glsp-client', 'glsp-server-node');
-            setupWorkspaceStub();
-            execStub.throws(new Error('unlink failed'));
+            writeWorkspaceYaml('glsp-server-node', {
+                overrides: { '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol' }
+            });
+            execAsyncStub.rejects(new Error('install failed'));
             try {
                 await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
                 expect.fail('should have thrown');

--- a/dev-packages/cli/src/commands/repo/link.ts
+++ b/dev-packages/cli/src/commands/repo/link.ts
@@ -15,86 +15,210 @@
  ********************************************************************************/
 
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as path from 'path';
 import { Command, Option } from 'commander';
-import { GLSPRepo, LOGGER, PRESET_NAMES, PackageHelper, baseCommand, exec, execAsync, getYarnWorkspacePackages } from '../../util';
+import * as YAML from 'yaml';
+import {
+    GLSPRepo,
+    LOGGER,
+    PRESET_NAMES,
+    PackageHelper,
+    baseCommand,
+    execAsync,
+    getWorkspacePackages,
+    readFile,
+    writeFile
+} from '../../util';
+import { buildSingleRepo } from './build';
 import { configureRepoEnv, formatError, getBuildOrder, isLeafRepo, resolveTargetRepos, validateReposExist } from './common/utils';
 
 // ── Action ──────────────────────────────────────────────────────────────────
 
+// Peer deps shared from glsp-client via pnpm `overrides` so they resolve to a single instance across linked
+// repos (DI container/`TYPES`/`instanceof`). reflect-metadata is intentionally excluded: it dedupes via a
+// global registry, and overriding it breaks `types: ['reflect-metadata']` resolution in linked builds.
 export const SINGLETON_DEPS = ['sprotty', 'sprotty-protocol', 'vscode-jsonrpc', 'inversify'] as const;
 
-const YARN_EXEC_OPTS = { silent: false, env: { FORCE_COLOR: '1' } } as const;
+const PNPM_EXEC_OPTS = { silent: false, env: { FORCE_COLOR: '1' } } as const;
+
+// `overrides` mutate the lockfile, so it must be updatable (CI defaults to a frozen lockfile).
+const PNPM_INSTALL = 'pnpm install --no-frozen-lockfile';
+
+const WORKSPACE_YAML = 'pnpm-workspace.yaml';
 
 const LINKABLE_REPOS: readonly GLSPRepo[] = [
     'glsp',
     'glsp-client',
     'glsp-server-node',
     'glsp-theia-integration',
-    'glsp-vscode-integration'
+    'glsp-vscode-integration',
+    'glsp-eclipse-integration'
 ];
+
+// Repos whose linkable pnpm workspace is not the repo root: glsp-eclipse-integration links its client/
+// tree (the server/ is Maven, not linked).
+const WORKSPACE_SUBDIR: Partial<Record<GLSPRepo, string>> = {
+    'glsp-eclipse-integration': 'client'
+};
+
+function resolveLinkWorkspaceDir(repoDir: string, repo: GLSPRepo): string {
+    const subdir = WORKSPACE_SUBDIR[repo];
+    return subdir ? path.join(repoDir, subdir) : repoDir;
+}
 
 export interface LinkActionOptions {
     dir: string;
     verbose: boolean;
     failFast: boolean;
+    /** Build each linked repo so overrides resolve to compiled `lib/` instead of source. Default `true`. */
+    build?: boolean;
+    /** Build the Theia electron variant instead of browser. */
+    electron?: boolean;
+}
+
+interface WorkspaceYaml extends Record<string, unknown> {
+    overrides?: Record<string, string>;
 }
 
 export function filterLinkableRepos(repos: GLSPRepo[]): GLSPRepo[] {
     return repos.filter(r => (LINKABLE_REPOS as readonly string[]).includes(r));
 }
 
-export function getGLSPWorkspacePackages(repoDir: string): PackageHelper[] {
-    const packages = getYarnWorkspacePackages(repoDir);
-    return packages.filter(pkg => pkg.name.startsWith('@eclipse-glsp'));
+// Matches @eclipse-glsp/* and @eclipse-glsp-examples/*.
+function isGlspPackageName(name: string): boolean {
+    return name.startsWith('@eclipse-glsp');
 }
 
-export function getRegisteredPackages(linkDir: string): string[] {
-    const packages: string[] = [];
-    if (!fs.existsSync(linkDir)) {
-        return packages;
+export function getGLSPWorkspacePackages(repoDir: string): PackageHelper[] {
+    return getWorkspacePackages(repoDir).filter(pkg => isGlspPackageName(pkg.name));
+}
+
+/** Maps the @eclipse-glsp workspace packages a repo provides to their absolute locations. */
+export function collectProvidedPackages(repoDir: string): Record<string, string> {
+    const provided: Record<string, string> = {};
+    for (const pkg of getGLSPWorkspacePackages(repoDir)) {
+        provided[pkg.name] = pkg.location;
     }
-    for (const entry of fs.readdirSync(linkDir)) {
-        const entryPath = path.join(linkDir, entry);
-        if (entry.startsWith('@') && fs.statSync(entryPath).isDirectory()) {
-            for (const sub of fs.readdirSync(entryPath)) {
-                packages.push(`${entry}/${sub}`);
+    return provided;
+}
+
+// Walks up from a module entry to its package root: nearest package.json whose `name` matches (skips
+// nested manifests like inversify's lib/cjs/package.json), falling back to the first manifest found.
+function packageRootOf(entryPath: string, name: string): string | undefined {
+    let dir = path.dirname(entryPath);
+    let fallback: string | undefined;
+    while (dir !== path.dirname(dir)) {
+        const manifest = path.join(dir, 'package.json');
+        if (fs.existsSync(manifest)) {
+            fallback ??= dir;
+            try {
+                if ((JSON.parse(fs.readFileSync(manifest, 'utf8')) as { name?: string }).name === name) {
+                    return dir;
+                }
+            } catch {
+                // ignore malformed manifest and keep walking up
             }
         }
+        if (path.basename(dir) === 'node_modules') {
+            break;
+        }
+        dir = path.dirname(dir);
     }
-    return packages;
+    return fallback;
 }
 
-export function registerPackages(repoDir: string, linkDir: string): string[] {
-    const packages = getGLSPWorkspacePackages(repoDir);
-    const registered: string[] = [];
-    for (const pkg of packages) {
-        LOGGER.debug(`Registering ${pkg.name}`);
-        exec(`yarn link --link-folder ${linkDir}`, { cwd: pkg.location, ...YARN_EXEC_OPTS });
-        registered.push(pkg.name);
+/** Resolves `dep`'s package dir as seen from one of `fromDirs` (the copy glsp-client uses), or undefined. */
+export function resolveSingletonDir(fromDirs: string[], dep: string): string | undefined {
+    for (const from of fromDirs) {
+        try {
+            const requireFrom = createRequire(path.join(from, 'package.json'));
+            const root = packageRootOf(fs.realpathSync(requireFrom.resolve(dep)), dep);
+            if (root) {
+                return root;
+            }
+        } catch {
+            // not resolvable from this directory; try the next
+        }
     }
-    return registered;
+    return undefined;
 }
 
-export function registerSingletons(clientDir: string, linkDir: string): void {
+// Collects the singletons as resolved within glsp-client. They are peers of the GLSP packages, so resolve
+// from those package dirs (which provide them), not the repo root.
+export function collectSingletonLinks(clientDir: string): Record<string, string> {
+    const fromDirs = [...getGLSPWorkspacePackages(clientDir).map(pkg => pkg.location), clientDir];
+    const links: Record<string, string> = {};
     for (const dep of SINGLETON_DEPS) {
-        const depDir = path.join(clientDir, 'node_modules', dep);
-        LOGGER.debug(`Registering singleton ${dep}`);
-        exec(`yarn link --link-folder ${linkDir}`, { cwd: depDir, ...YARN_EXEC_OPTS });
+        const dir = resolveSingletonDir(fromDirs, dep);
+        if (dir) {
+            links[dep] = dir;
+        } else {
+            LOGGER.debug(`Singleton ${dep} not found in ${path.basename(clientDir)}, skipping`);
+        }
     }
+    return links;
 }
 
-export function consumePackages(repoDir: string, linkDir: string, registeredPackages: string[]): void {
-    if (registeredPackages.length === 0) {
+function isManagedLinkOverride(key: string, value: unknown): boolean {
+    return (
+        typeof value === 'string' &&
+        value.startsWith('link:') &&
+        (isGlspPackageName(key) || (SINGLETON_DEPS as readonly string[]).includes(key))
+    );
+}
+
+function currentOverrides(doc: YAML.Document): Record<string, string> {
+    return ((doc.toJS() as WorkspaceYaml | null)?.overrides ?? {}) as Record<string, string>;
+}
+
+/** Detects the indentation width of a YAML source so re-serialization keeps the original layout. */
+function detectIndent(source: string): number {
+    const match = source.match(/^( +)\S/m);
+    return match ? match[1].length : 2;
+}
+
+// Injects `link:` overrides (repo-relative paths) into pnpm-workspace.yaml, edited via the YAML document
+// model so existing entries, comments and formatting are preserved.
+export function applyLinkOverrides(repoDir: string, links: Record<string, string>): void {
+    if (Object.keys(links).length === 0) {
         return;
     }
-    LOGGER.debug(`Linking ${registeredPackages.join(', ')} into ${path.basename(repoDir)}`);
-    exec(`yarn link --link-folder ${linkDir} ${registeredPackages.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+    const yamlPath = path.resolve(repoDir, WORKSPACE_YAML);
+    const source = fs.existsSync(yamlPath) ? readFile(yamlPath) : '';
+    const doc = source ? YAML.parseDocument(source) : new YAML.Document({});
+    for (const [name, target] of Object.entries(links)) {
+        const relative = path.relative(repoDir, target) || '.';
+        doc.setIn(['overrides', name], `link:${relative}`);
+        LOGGER.debug(`Link ${name} -> link:${relative}`);
+    }
+    writeFile(yamlPath, doc.toString({ indent: detectIndent(source) }));
 }
 
-export function consumeSingletons(repoDir: string, linkDir: string): void {
-    LOGGER.debug(`Linking singletons into ${path.basename(repoDir)}`);
-    exec(`yarn link --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+// Removes the overrides injected by applyLinkOverrides; leaves unrelated overrides untouched. Returns
+// whether anything was removed.
+export function removeLinkOverrides(repoDir: string): boolean {
+    const yamlPath = path.resolve(repoDir, WORKSPACE_YAML);
+    if (!fs.existsSync(yamlPath)) {
+        return false;
+    }
+    const source = readFile(yamlPath);
+    const doc = YAML.parseDocument(source);
+    let removed = false;
+    for (const [key, value] of Object.entries(currentOverrides(doc))) {
+        if (isManagedLinkOverride(key, value)) {
+            doc.deleteIn(['overrides', key]);
+            removed = true;
+            LOGGER.debug(`Unlink ${key}`);
+        }
+    }
+    if (Object.keys(currentOverrides(doc)).length === 0) {
+        doc.delete('overrides');
+    }
+    if (removed) {
+        writeFile(yamlPath, doc.toString({ indent: detectIndent(source) }));
+    }
+    return removed;
 }
 
 export async function runLink(repos: GLSPRepo[], options: LinkActionOptions): Promise<void> {
@@ -108,9 +232,9 @@ export async function runLink(repos: GLSPRepo[], options: LinkActionOptions): Pr
     }
 
     validateReposExist(linkable, options.dir);
-    const linkDir = path.resolve(options.dir, '.yarn-link');
     const ordered = getBuildOrder(linkable);
-    const registeredPackages: string[] = [];
+    const providedPackages: Record<string, string> = {};
+    let singletonLinks: Record<string, string> = {};
     let failures = 0;
 
     LOGGER.label('Linking repositories');
@@ -122,26 +246,37 @@ export async function runLink(repos: GLSPRepo[], options: LinkActionOptions): Pr
                 LOGGER.newLine();
             }
             const repoDir = path.resolve(options.dir, repo);
+            const workspaceDir = resolveLinkWorkspaceDir(repoDir, repo);
             LOGGER.info(`Linking ${repo}...`);
 
-            const packagesFromPriorRepos = [...registeredPackages];
-
-            if (!isLeafRepo(repo)) {
-                const registered = registerPackages(repoDir, linkDir);
-                registeredPackages.push(...registered);
-            }
-
-            if (repo === 'glsp-client') {
-                await execAsync('yarn install', { cwd: repoDir, ...YARN_EXEC_OPTS });
-                registerSingletons(repoDir, linkDir);
-            }
-
-            await execAsync('yarn install --force', { cwd: repoDir, ...YARN_EXEC_OPTS });
-
-            consumePackages(repoDir, linkDir, packagesFromPriorRepos);
-
+            // Consume the packages registered by repos earlier in the build order (plus the shared singletons).
+            const links: Record<string, string> = { ...providedPackages };
             if (repo !== 'glsp-client' && linkable.includes('glsp-client')) {
-                consumeSingletons(repoDir, linkDir);
+                Object.assign(links, singletonLinks);
+            }
+            applyLinkOverrides(workspaceDir, links);
+
+            await execAsync(PNPM_INSTALL, { cwd: workspaceDir, ...PNPM_EXEC_OPTS });
+
+            // Build so the linked `lib/` exists for the next consumer. Install already ran above; skip
+            // Java/Maven since only the npm side is linked.
+            if (options.build ?? true) {
+                await buildSingleRepo(repo, {
+                    dir: options.dir,
+                    electron: options.electron ?? false,
+                    verbose: options.verbose,
+                    failFast: options.failFast,
+                    install: false,
+                    java: false
+                });
+            }
+
+            // Register what this repo provides for repos later in the build order.
+            if (!isLeafRepo(repo)) {
+                Object.assign(providedPackages, collectProvidedPackages(workspaceDir));
+            }
+            if (repo === 'glsp-client') {
+                singletonLinks = collectSingletonLinks(workspaceDir);
             }
 
             LOGGER.info(`Successfully linked ${repo}`);
@@ -169,9 +304,7 @@ export async function runUnlink(repos: GLSPRepo[], options: LinkActionOptions): 
     }
 
     validateReposExist(linkable, options.dir);
-    const linkDir = path.resolve(options.dir, '.yarn-link');
-    const ordered = getBuildOrder(linkable);
-    const reversed = ordered.toReversed();
+    const reversed = getBuildOrder(linkable).toReversed();
     let failures = 0;
 
     LOGGER.label('Unlinking repositories');
@@ -183,34 +316,15 @@ export async function runUnlink(repos: GLSPRepo[], options: LinkActionOptions): 
                 LOGGER.newLine();
             }
             const repoDir = path.resolve(options.dir, repo);
+            const workspaceDir = resolveLinkWorkspaceDir(repoDir, repo);
             LOGGER.info(`Unlinking ${repo}...`);
 
-            if (repo !== 'glsp-client' && linkable.includes('glsp-client')) {
-                exec(`yarn unlink --link-folder ${linkDir} ${SINGLETON_DEPS.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
+            const removed = removeLinkOverrides(workspaceDir);
+            if (removed) {
+                await execAsync(PNPM_INSTALL, { cwd: workspaceDir, ...PNPM_EXEC_OPTS });
+            } else {
+                LOGGER.debug(`No link overrides found for ${repo}, skipping reinstall`);
             }
-
-            const allLinkedPackages = getRegisteredPackages(linkDir);
-            if (allLinkedPackages.length > 0) {
-                exec(`yarn unlink --link-folder ${linkDir} ${allLinkedPackages.join(' ')}`, { cwd: repoDir, ...YARN_EXEC_OPTS });
-            }
-
-            if (repo === 'glsp-client') {
-                for (const dep of SINGLETON_DEPS) {
-                    const depDir = path.join(repoDir, 'node_modules', dep);
-                    if (fs.existsSync(depDir)) {
-                        exec(`yarn unlink --link-folder ${linkDir}`, { cwd: depDir, ...YARN_EXEC_OPTS });
-                    }
-                }
-            }
-
-            if (!isLeafRepo(repo)) {
-                const packages = getGLSPWorkspacePackages(repoDir);
-                for (const pkg of packages) {
-                    exec(`yarn unlink --link-folder ${linkDir}`, { cwd: pkg.location, ...YARN_EXEC_OPTS });
-                }
-            }
-
-            await execAsync('yarn install --force', { cwd: repoDir, ...YARN_EXEC_OPTS });
 
             LOGGER.info(`Successfully unlinked ${repo}`);
         } catch (error) {
@@ -237,14 +351,18 @@ interface LinkCliOptions {
     repo?: string[];
     preset?: string;
     failFast: boolean;
+    build: boolean;
+    electron: boolean;
 }
 
 export const LinkCommand = baseCommand()
     .name('link')
-    .description('Interlink repositories via yarn link')
+    .description('Interlink repositories via pnpm-workspace.yaml link overrides')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .addOption(new Option('-r, --repo <name...>', 'Link only these repos'))
     .addOption(new Option('--preset <name>', 'Link repos from a preset').choices(PRESET_NAMES))
+    .option('--no-build', 'Skip building the linked repos (links resolve to existing compiled output)')
+    .option('--electron', 'Build the Theia electron variant instead of browser', false)
     .option('--no-fail-fast', 'Continue after a failure')
     .option('-v, --verbose', 'Verbose output', false)
     .action(async (_cmdOptions: LinkCliOptions, thisCmd: Command) => {
@@ -253,7 +371,7 @@ export const LinkCommand = baseCommand()
         const { dir, repos } = resolveTargetRepos(cli);
 
         try {
-            await runLink(repos, { dir, verbose: cli.verbose, failFast: cli.failFast });
+            await runLink(repos, { dir, verbose: cli.verbose, failFast: cli.failFast, build: cli.build, electron: cli.electron });
         } catch {
             process.exitCode = 1;
         }
@@ -261,7 +379,7 @@ export const LinkCommand = baseCommand()
 
 export const UnlinkCommand = baseCommand()
     .name('unlink')
-    .description('Remove yarn links between repositories')
+    .description('Remove the pnpm link overrides between repositories')
     .option('-d, --dir <path>', 'Target directory where repos are cloned')
     .addOption(new Option('-r, --repo <name...>', 'Unlink only these repos'))
     .addOption(new Option('--preset <name>', 'Unlink repos from a preset').choices(PRESET_NAMES))

--- a/dev-packages/cli/src/commands/repo/run.ts
+++ b/dev-packages/cli/src/commands/repo/run.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import { Command } from 'commander';
-import { GLSPRepo, baseCommand, detectPackageManager, execForeground, runScriptCommand } from '../../util';
+import { GLSPRepo, baseCommand, execForeground } from '../../util';
 import { configureRepoEnv, resolveWorkspaceDir } from './common/utils';
 
 export function createScopedRunCommand(repo: GLSPRepo): Command {
@@ -34,8 +34,7 @@ export function createScopedRunCommand(repo: GLSPRepo): Command {
             const dir = resolveWorkspaceDir(cli.dir);
             const repoDir = path.resolve(dir, repo);
             const passthrough = thisCmd.args.slice(1).join(' ');
-            const pm = detectPackageManager(repoDir);
-            const cmd = runScriptCommand(pm, passthrough ? `${script} ${passthrough}` : script);
+            const cmd = `pnpm run ${passthrough ? `${script} ${passthrough}` : script}`;
             await execForeground(cmd, { cwd: repoDir, verbose: cli.verbose });
         });
 }

--- a/dev-packages/cli/src/commands/repo/start.spec.ts
+++ b/dev-packages/cli/src/commands/repo/start.spec.ts
@@ -83,31 +83,22 @@ describe('start-action', () => {
     });
 
     describe('resolveCommand', () => {
-        it('should resolve to a yarn --cwd command for yarn repos', () => {
-            fs.writeFileSync(path.join(tempDir, 'yarn.lock'), '');
-            const result = resolveCommand('start:websocket', tempDir, false);
-            expect(result).to.equal(`yarn --cwd ${tempDir} start:websocket`);
-        });
-
-        it('should resolve to a pnpm -C command for pnpm repos', () => {
-            fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), '');
+        it('should resolve to a pnpm -C command', () => {
             const result = resolveCommand('start:websocket', tempDir, false);
             expect(result).to.equal(`pnpm -C ${tempDir} start:websocket`);
         });
 
         it('should return undefined on dry-run', () => {
-            fs.writeFileSync(path.join(tempDir, 'yarn.lock'), '');
             const result = resolveCommand('start:websocket', tempDir, true);
             expect(result).to.be.undefined;
         });
 
         it('should handle scripts with arguments', () => {
-            fs.writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '');
             const result = resolveCommand('start:websocket --port 8081', tempDir, false);
             expect(result).to.equal(`pnpm -C ${tempDir} start:websocket --port 8081`);
         });
 
-        it('should fall back to pnpm when the repo is not cloned yet', () => {
+        it('should work even when the repo is not cloned yet', () => {
             const result = resolveCommand('start:websocket', '/not/cloned/repo', false);
             expect(result).to.equal('pnpm -C /not/cloned/repo start:websocket');
         });

--- a/dev-packages/cli/src/commands/repo/start.ts
+++ b/dev-packages/cli/src/commands/repo/start.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import { Command } from 'commander';
-import { LOGGER, PackageManager, baseCommand, detectPackageManager, execForeground, runScriptInDirCommand } from '../../util';
+import { LOGGER, baseCommand, execForeground } from '../../util';
 import { configureRepoEnv, discoverNewestFile, resolveWorkspaceDir } from './common/utils';
 
 // ── Action ──────────────────────────────────────────────────────────────────
@@ -37,14 +37,7 @@ function collectPassthroughArgs(cmd: Command): string {
 }
 
 export function resolveCommand(script: string, repoDir: string, dryRun: boolean): string | undefined {
-    let pm: PackageManager;
-    try {
-        pm = detectPackageManager(repoDir);
-    } catch (error) {
-        // e.g. dry runs may target repos that are not cloned yet — assume pnpm (the target state)
-        pm = 'pnpm';
-    }
-    const resolved = runScriptInDirCommand(pm, repoDir, script);
+    const resolved = `pnpm -C ${repoDir} ${script}`;
     if (dryRun) {
         process.stdout.write(resolved + '\n');
         return undefined;

--- a/dev-packages/cli/src/commands/repo/vscode.ts
+++ b/dev-packages/cli/src/commands/repo/vscode.ts
@@ -16,7 +16,7 @@
 
 import { Command } from 'commander';
 import * as path from 'path';
-import { baseCommand, detectPackageManager, execAsync, runScriptCommand } from '../../util';
+import { baseCommand, execAsync } from '../../util';
 import { VSIX_TARGET_DIR, WEB_VSIX_TARGET_DIR, configureRepoEnv, discoverNewestFile, resolveWorkspaceDir } from './common/utils';
 
 export const VSIX_ID = 'eclipse-glsp.workflow-vscode-example';
@@ -34,7 +34,7 @@ export const VscodePackageCommand: Command = baseCommand()
         configureRepoEnv(cli);
         const dir = resolveWorkspaceDir(cli.dir);
         const repoDir = path.resolve(dir, 'glsp-vscode-integration');
-        await execAsync(runScriptCommand(detectPackageManager(repoDir), 'workflow package'), {
+        await execAsync('pnpm run workflow package', {
             cwd: repoDir,
             silent: false,
             env: { FORCE_COLOR: '1' }
@@ -51,7 +51,7 @@ export const VscodeWebPackageCommand: Command = baseCommand()
         configureRepoEnv(cli);
         const dir = resolveWorkspaceDir(cli.dir);
         const repoDir = path.resolve(dir, 'glsp-vscode-integration');
-        await execAsync(runScriptCommand(detectPackageManager(repoDir), 'workflow:web package'), {
+        await execAsync('pnpm run workflow:web package', {
             cwd: repoDir,
             silent: false,
             env: { FORCE_COLOR: '1' }

--- a/dev-packages/cli/src/commands/update-next.spec.ts
+++ b/dev-packages/cli/src/commands/update-next.spec.ts
@@ -67,7 +67,6 @@ describe('updateNext', () => {
     }
 
     it('should pin next deps via pnpm-workspace.yaml overrides and install (without opportunistic updates)', async () => {
-        sandbox.stub(packageUtil, 'detectPackageManager').returns('pnpm');
         createPackage('.', { name: 'root', private: true });
         const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', dependencies: { '@eclipse-glsp/protocol': 'next' } });
         sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
@@ -90,7 +89,6 @@ describe('updateNext', () => {
     });
 
     it('should merge into an existing overrides block (ours win) and restore it afterwards', async () => {
-        sandbox.stub(packageUtil, 'detectPackageManager').returns('pnpm');
         createPackage('.', { name: 'root', private: true });
         const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', dependencies: { '@eclipse-glsp/protocol': 'next' } });
         sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
@@ -114,27 +112,11 @@ describe('updateNext', () => {
     });
 
     it('should do nothing when a pnpm repo has no next dependencies', async () => {
-        sandbox.stub(packageUtil, 'detectPackageManager').returns('pnpm');
         const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', dependencies: { '@eclipse-glsp/protocol': '^2.0.0' } });
         sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
 
         await updateNext(tempDir, { verbose: false });
 
         expect(execAsyncStub.notCalled).to.be.true;
-    });
-
-    it('should use yarn resolutions for a yarn repo', async () => {
-        sandbox.stub(packageUtil, 'detectPackageManager').returns('yarn');
-        const pkgA = createPackage('packages/a', { name: '@eclipse-glsp/a', dependencies: { '@eclipse-glsp/protocol': 'next' } });
-        createPackage('.', { name: 'root', private: true });
-        sandbox.stub(packageUtil, 'getWorkspacePackages').returns([pkgA]);
-        execStub.withArgs(sinon.match(/npm view/)).returns('2.8.0-next.42');
-
-        await updateNext(tempDir, { verbose: false });
-
-        // the yarn path installs via yarn, never via pnpm
-        const commands = execAsyncStub.getCalls().map(call => call.args[0] as string);
-        expect(commands.some(cmd => cmd.includes('yarn install'))).to.be.true;
-        expect(commands.some(cmd => cmd.includes('pnpm'))).to.be.false;
     });
 });

--- a/dev-packages/cli/src/commands/update-next.ts
+++ b/dev-packages/cli/src/commands/update-next.ts
@@ -22,13 +22,11 @@ import {
     baseCommand,
     configureExec,
     configureLogger,
-    detectPackageManager,
     exec,
     execAsync,
     getUncommittedChanges,
     getWorkspacePackages,
     readFile,
-    readPackage,
     validateGitDirectory,
     writeFile
 } from '../util';
@@ -54,54 +52,31 @@ export async function updateNext(rootDir: string, options: { verbose: boolean })
 
     LOGGER.info('Updating next dependencies ...');
     rootDir = path.resolve(rootDir);
-    const pm = detectPackageManager(rootDir);
     const packages = getWorkspacePackages(rootDir, true);
 
-    if (pm === 'pnpm') {
-        LOGGER.debug(`Scanning ${packages.length} packages for 'next' dependencies`, packages);
-        const versions = resolveNextVersions(getNextDependencies(packages));
-        if (Object.keys(versions).length === 0) {
-            LOGGER.info('No next dependencies found');
-            return;
-        }
-        LOGGER.info('Upgrade and rebuild packages ...');
-        LOGGER.debug('Pinning next dependencies via pnpm-workspace.yaml overrides', versions);
-
-        const workspaceYamlPath = path.join(rootDir, 'pnpm-workspace.yaml');
-        const originalYaml = readFile(workspaceYamlPath);
-        // Merge our pins into any existing `overrides` (ours win); the file is restored verbatim afterwards.
-        const workspace = (YAML.parse(originalYaml) as { overrides?: Record<string, string> }) ?? {};
-        workspace.overrides = { ...workspace.overrides, ...versions };
-        writeFile(workspaceYamlPath, YAML.stringify(workspace));
-        try {
-            await execAsync('pnpm install', { silent: false, cwd: rootDir });
-        } finally {
-            LOGGER.debug('Restoring pnpm-workspace.yaml');
-            writeFile(workspaceYamlPath, originalYaml);
-        }
-        // Reconcile the lockfile with the restored pnpm-workspace.yaml (drops the temporary overrides)
-        await execAsync('pnpm install', { silent: false, cwd: rootDir });
-        LOGGER.info('Upgrade successfully completed');
-        return;
-    }
-
-    LOGGER.debug(`Scanning ${packages.length} packages to derive resolutions`, packages);
-    const resolutions = await getResolutions(packages);
-    if (Object.keys(resolutions).length === 0) {
+    LOGGER.debug(`Scanning ${packages.length} packages for 'next' dependencies`, packages);
+    const versions = resolveNextVersions(getNextDependencies(packages));
+    if (Object.keys(versions).length === 0) {
         LOGGER.info('No next dependencies found');
         return;
     }
     LOGGER.info('Upgrade and rebuild packages ...');
-    LOGGER.debug('Updating package.json with resolutions', resolutions);
-    const rootPkg = readPackage(rootPkgPath);
-    rootPkg.content.resolutions = resolutions;
-    rootPkg.write();
-    LOGGER.debug('Running yarn install');
-    await execAsync('yarn install --ignore-scripts', { silent: false, cwd: rootDir });
-    LOGGER.debug('Reverting package.json');
-    exec('git checkout HEAD -- package.json', { silent: true, cwd: rootDir });
-    LOGGER.debug('Rebuild to update yarn.lock');
-    await execAsync('yarn', { silent: false, cwd: rootDir });
+    LOGGER.debug('Pinning next dependencies via pnpm-workspace.yaml overrides', versions);
+
+    const workspaceYamlPath = path.join(rootDir, 'pnpm-workspace.yaml');
+    const originalYaml = readFile(workspaceYamlPath);
+    // Merge our pins into any existing `overrides` (ours win); the file is restored verbatim afterwards.
+    const workspace = (YAML.parse(originalYaml) as { overrides?: Record<string, string> }) ?? {};
+    workspace.overrides = { ...workspace.overrides, ...versions };
+    writeFile(workspaceYamlPath, YAML.stringify(workspace));
+    try {
+        await execAsync('pnpm install', { silent: false, cwd: rootDir });
+    } finally {
+        LOGGER.debug('Restoring pnpm-workspace.yaml');
+        writeFile(workspaceYamlPath, originalYaml);
+    }
+    // Reconcile the lockfile with the restored pnpm-workspace.yaml (drops the temporary overrides)
+    await execAsync('pnpm install', { silent: false, cwd: rootDir });
     LOGGER.info('Upgrade successfully completed');
 }
 
@@ -131,14 +106,4 @@ function resolveNextVersions(dependencies: string[]): Record<string, string> {
         versions[dep] = exec(`npm view ${dep}@next version`, { silent: true }).trim();
     });
     return versions;
-}
-
-async function getResolutions(packages: PackageHelper[]): Promise<Record<string, string>> {
-    LOGGER.info('Retrieve next versions ... ');
-    const versions = resolveNextVersions(getNextDependencies(packages));
-    const resolutions: Record<string, string> = {};
-    Object.entries(versions).forEach(([dep, version]) => {
-        resolutions[`**/${dep}`] = version;
-    });
-    return resolutions;
 }

--- a/dev-packages/cli/src/util/package-util.spec.ts
+++ b/dev-packages/cli/src/util/package-util.spec.ts
@@ -19,16 +19,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { cleanupTempDir, createTempDir } from '../../tests/helpers/test-helper';
+import { PackageHelper, getWorkspacePackages } from './package-util';
 import * as processUtil from './process-util';
-import {
-    PackageHelper,
-    detectPackageManager,
-    execBinCommand,
-    getPnpmWorkspacePackages,
-    getYarnWorkspaceInfo,
-    installCommand,
-    runScriptCommand
-} from './package-util';
 
 describe('package-util', () => {
     const sandbox = sinon.createSandbox();
@@ -65,58 +57,7 @@ describe('package-util', () => {
         });
     });
 
-    describe('detectPackageManager', () => {
-        let tempDir: string;
-
-        beforeEach(() => {
-            tempDir = createTempDir();
-        });
-
-        afterEach(() => {
-            cleanupTempDir(tempDir);
-        });
-
-        it('should detect pnpm if a pnpm-workspace.yaml is present', () => {
-            fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
-            expect(detectPackageManager(tempDir)).to.equal('pnpm');
-        });
-
-        it('should detect pnpm if a pnpm-lock.yaml is present', () => {
-            fs.writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '');
-            expect(detectPackageManager(tempDir)).to.equal('pnpm');
-        });
-
-        it('should detect yarn if a yarn.lock is present', () => {
-            fs.writeFileSync(path.join(tempDir, 'yarn.lock'), '');
-            expect(detectPackageManager(tempDir)).to.equal('yarn');
-        });
-
-        it('should prefer pnpm if both pnpm and yarn files are present', () => {
-            fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), '');
-            fs.writeFileSync(path.join(tempDir, 'yarn.lock'), '');
-            expect(detectPackageManager(tempDir)).to.equal('pnpm');
-        });
-
-        it('should throw if no package manager could be detected', () => {
-            expect(() => detectPackageManager(tempDir)).to.throw(/Could not detect the package manager/);
-        });
-    });
-
-    describe('package manager command helpers', () => {
-        it('should return the pnpm command variants', () => {
-            expect(installCommand('pnpm')).to.equal('pnpm install');
-            expect(runScriptCommand('pnpm', 'build')).to.equal('pnpm run build');
-            expect(execBinCommand('pnpm', 'nyc -h')).to.equal('pnpm exec nyc -h');
-        });
-
-        it('should return the yarn command variants', () => {
-            expect(installCommand('yarn')).to.equal('yarn install');
-            expect(runScriptCommand('yarn', 'build')).to.equal('yarn build');
-            expect(execBinCommand('yarn', 'nyc -h')).to.equal('yarn nyc -h');
-        });
-    });
-
-    describe('getPnpmWorkspacePackages', () => {
+    describe('getWorkspacePackages', () => {
         let tempDir: string;
 
         beforeEach(() => {
@@ -145,7 +86,7 @@ describe('package-util', () => {
             ]);
             sandbox.stub(processUtil, 'exec').returns(listOutput);
 
-            const packages = getPnpmWorkspacePackages(tempDir);
+            const packages = getWorkspacePackages(tempDir);
             expect(packages.map(pkg => pkg.name)).to.deep.equal(['@scope/pkg-a', '@scope/pkg-b']);
             expect(packages.map(pkg => pkg.location)).to.deep.equal([pkgADir, pkgBDir]);
         });
@@ -159,40 +100,9 @@ describe('package-util', () => {
             ]);
             sandbox.stub(processUtil, 'exec').returns(listOutput);
 
-            const packages = getPnpmWorkspacePackages(tempDir, true);
+            const packages = getWorkspacePackages(tempDir, true);
             expect(packages.map(pkg => pkg.name)).to.deep.equal(['@scope/pkg-a', 'root']);
             expect(packages[packages.length - 1].location).to.equal(tempDir);
-        });
-    });
-
-    describe('getYarnWorkspaceInfo', () => {
-        it('should extract and parse JSON from valid yarn workspaces output', () => {
-            const yarnOutput = [
-                'yarn workspaces info v1.22.0',
-                '{',
-                '  "@scope/pkg-a": {',
-                '    "location": "packages/a",',
-                '    "workspaceDependencies": [],',
-                '    "mismatchedWorkspaceDependencies": []',
-                '  }',
-                '}',
-                'Done in 0.01s.'
-            ].join('\n');
-
-            sandbox.stub(processUtil, 'exec').returns(yarnOutput);
-
-            const info = getYarnWorkspaceInfo('/some/root');
-            expect(info).to.not.be.undefined;
-            expect(info!['@scope/pkg-a'].location).to.equal('packages/a');
-            expect(info!['@scope/pkg-a'].workspaceDependencies).to.deep.equal([]);
-            expect(info!['@scope/pkg-a'].mismatchedWorkspaceDependencies).to.deep.equal([]);
-        });
-
-        it('should return undefined when exec throws', () => {
-            sandbox.stub(processUtil, 'exec').throws(new Error('command failed'));
-
-            const info = getYarnWorkspaceInfo('/some/root');
-            expect(info).to.be.undefined;
         });
     });
 });

--- a/dev-packages/cli/src/util/package-util.ts
+++ b/dev-packages/cli/src/util/package-util.ts
@@ -108,55 +108,6 @@ export function readPackage(packagePath: string): PackageHelper {
     return new PackageHelper(packagePath, packageData.name);
 }
 
-export type PackageManager = 'pnpm' | 'yarn';
-
-/**
- * Detects the package manager of the given repository by checking for package-manager-specific files.
- * @param rootPath The root path of the repository
- * @returns `pnpm` if a `pnpm-workspace.yaml` or `pnpm-lock.yaml` is present, `yarn` if a `yarn.lock` is present
- * @throws Error if no package manager could be detected
- */
-export function detectPackageManager(rootPath: string): PackageManager {
-    if (fs.existsSync(path.resolve(rootPath, 'pnpm-workspace.yaml')) || fs.existsSync(path.resolve(rootPath, 'pnpm-lock.yaml'))) {
-        return 'pnpm';
-    }
-    if (fs.existsSync(path.resolve(rootPath, 'yarn.lock'))) {
-        return 'yarn';
-    }
-    throw new Error(
-        `Could not detect the package manager of '${rootPath}'.` +
-            ' Expected a pnpm-workspace.yaml/pnpm-lock.yaml (pnpm) or a yarn.lock (yarn) in the repository root.'
-    );
-}
-
-/**
- * Returns the install command for the given package manager.
- */
-export function installCommand(pm: PackageManager): string {
-    return pm === 'pnpm' ? 'pnpm install' : 'yarn install';
-}
-
-/**
- * Returns the command to run a package.json script with the given package manager.
- */
-export function runScriptCommand(pm: PackageManager, script: string): string {
-    return pm === 'pnpm' ? `pnpm run ${script}` : `yarn ${script}`;
-}
-
-/**
- * Returns the command to execute a binary from the workspace's node_modules with the given package manager.
- */
-export function execBinCommand(pm: PackageManager, bin: string): string {
-    return pm === 'pnpm' ? `pnpm exec ${bin}` : `yarn ${bin}`;
-}
-
-/**
- * Returns the command to run a package.json script in the given directory with the given package manager.
- */
-export function runScriptInDirCommand(pm: PackageManager, dir: string, script: string): string {
-    return pm === 'pnpm' ? `pnpm -C ${dir} ${script}` : `yarn --cwd ${dir} ${script}`;
-}
-
 export interface PnpmWorkspaceProject {
     name: string;
     version: string;
@@ -171,7 +122,7 @@ export interface PnpmWorkspaceProject {
  * @param includeRoot Whether to include the root package.json as well
  * @returns The package helpers of all workspace packages (excluding the root unless `includeRoot` is set)
  */
-export function getPnpmWorkspacePackages(rootPath: string, includeRoot = false): PackageHelper[] {
+export function getWorkspacePackages(rootPath: string, includeRoot = false): PackageHelper[] {
     const result = exec('pnpm -r list --json --depth -1', { cwd: rootPath, silent: true });
     const projects = JSON.parse(result) as PnpmWorkspaceProject[];
     const rootPackagePath = path.resolve(rootPath, 'package.json');
@@ -180,68 +131,6 @@ export function getPnpmWorkspacePackages(rootPath: string, includeRoot = false):
         .map(project => new PackageHelper(path.resolve(project.path, 'package.json'), project.name));
     if (includeRoot) {
         packages.push(new PackageHelper(rootPackagePath, 'root'));
-    }
-    return packages;
-}
-
-/**
- * Get all {@link PackageHelper}s of a workspace/mono repo, dispatching on the detected package manager.
- * @param rootPath The root path of the workspace
- * @param includeRoot Whether to include the root package.json as well
- * @returns The package helpers of all workspace packages
- */
-export function getWorkspacePackages(rootPath: string, includeRoot = false): PackageHelper[] {
-    return detectPackageManager(rootPath) === 'pnpm'
-        ? getPnpmWorkspacePackages(rootPath, includeRoot)
-        : getYarnWorkspacePackages(rootPath, includeRoot);
-}
-
-export interface YarnWorkspaceInfo {
-    location: string;
-    workspaceDependencies: string[];
-    mismatchedWorkspaceDependencies: string[];
-}
-
-export function isYarnMonorepo(rootPath: string): boolean {
-    return getYarnWorkspaceInfo(rootPath) !== undefined;
-}
-
-/**
- * Get the yarn (v1) workspace info by executing `yarn workspaces info` and parsing the result.
- * @param rootPath The root path of the yarn mono repo
- * @returns The parsed workspace info or `undefined` if the command failed (e.g. not a yarn mono repo)
- * @deprecated Use {@link getWorkspacePackages} instead. Will be removed once all GLSP repos are migrated to pnpm.
- */
-export function getYarnWorkspaceInfo(rootPath: string): Record<string, YarnWorkspaceInfo> | undefined {
-    try {
-        const result = exec('yarn workspaces info', { cwd: rootPath, silent: true });
-        // Trim the first and last line to extract the JSON object
-        const jsonStart = result.indexOf('{');
-        const jsonEnd = result.lastIndexOf('}');
-        const json = result.substring(jsonStart, jsonEnd + 1);
-        return JSON.parse(json) as Record<string, YarnWorkspaceInfo>;
-    } catch (error) {
-        return undefined;
-    }
-}
-
-/**
- *  Get all {@link PackageHelper}s of a yarn (v1) mono repo by executing `yarn workspaces info` and parsing the result.
- * @param rootPath The root path of the yarn mono repo
- * @param includeRoot Whether to include the root package.json as well
- * @returns The package helpers of all workspace packages
- * @deprecated Use {@link getWorkspacePackages} instead. Will be removed once all GLSP repos are migrated to pnpm.
- */
-export function getYarnWorkspacePackages(rootPath: string, includeRoot = false): PackageHelper[] {
-    const workspaces = getYarnWorkspaceInfo(rootPath);
-    if (!workspaces) {
-        return [];
-    }
-    const packages = Object.entries(workspaces).map(
-        ([name, info]) => new PackageHelper(path.resolve(rootPath, info.location, 'package.json'), name)
-    );
-    if (includeRoot) {
-        packages.push(new PackageHelper(path.resolve(rootPath, 'package.json'), 'root'));
     }
     return packages;
 }

--- a/dev-packages/cli/tests/e2e/releng/prepare.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/releng/prepare.e2e.spec.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as YAML from 'yaml';
 import { runCli } from '../../helpers/cli-helper';
 import { replaceOriginWithBare, shallowClone } from '../../helpers/clone-helper';
 import { cleanupTempDir } from '../../helpers/test-helper';
@@ -87,17 +88,25 @@ function injectChangelogSection(repoDir: string): void {
 }
 
 /**
- * Finds workspace package.json files (not the root) by reading the root
- * package.json workspaces globs and resolving them.
+ * Reads the workspace package globs of a repo. pnpm repos declare them in `pnpm-workspace.yaml`;
+ * legacy repos use the `workspaces` field in the root `package.json`.
+ */
+function readWorkspaceGlobs(repoDir: string): string[] {
+    const pnpmWorkspace = path.join(repoDir, 'pnpm-workspace.yaml');
+    if (fs.existsSync(pnpmWorkspace)) {
+        const parsed = YAML.parse(fs.readFileSync(pnpmWorkspace, 'utf8')) as { packages?: string[] };
+        return parsed?.packages ?? [];
+    }
+    const rootPkg = readJson(path.join(repoDir, 'package.json'));
+    return Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : ((rootPkg.workspaces as { packages?: string[] })?.packages ?? []);
+}
+
+/**
+ * Finds workspace package.json files (not the root) by resolving the workspace globs.
  */
 function findWorkspacePackageJsons(repoDir: string): string[] {
-    const rootPkg = readJson(path.join(repoDir, 'package.json'));
-    const workspaces: string[] = Array.isArray(rootPkg.workspaces)
-        ? rootPkg.workspaces
-        : ((rootPkg.workspaces as { packages?: string[] })?.packages ?? []);
-
     const results: string[] = [];
-    for (const pattern of workspaces) {
+    for (const pattern of readWorkspaceGlobs(repoDir)) {
         const base = pattern.replace(/\/?\*.*$/, '');
         const fullBase = path.join(repoDir, base);
         if (!fs.existsSync(fullBase)) {
@@ -155,10 +164,6 @@ describe('releng prepare — glsp', function () {
         // Version bumped in root package.json
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
         expect(rootPkg.version).to.equal('99.0.0');
-
-        // Version bumped in lerna.json
-        const lerna = readJson(path.join(repoDir, 'lerna.json'));
-        expect(lerna.version).to.equal('99.0.0');
 
         // At least one workspace package.json updated
         const workspacePkgs = findWorkspacePackageJsons(repoDir);
@@ -223,9 +228,6 @@ for (const repo of NPM_REPOS_WITH_EXTERNAL_DEPS) {
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
             expect(rootPkg.version as string).to.match(/-next$/);
 
-            const lerna = readJson(path.join(repoDir, 'lerna.json'));
-            expect(lerna.version as string).to.match(/-next$/);
-
             // At least one workspace package.json updated
             const workspacePkgs = findWorkspacePackageJsons(repoDir);
             expect(workspacePkgs.length).to.be.greaterThan(0);
@@ -280,9 +282,6 @@ describe('releng prepare — glsp-playwright', function () {
         // Version bumped with -next suffix
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
         expect(rootPkg.version as string).to.match(/-next$/);
-
-        const lerna = readJson(path.join(repoDir, 'lerna.json'));
-        expect(lerna.version as string).to.match(/-next$/);
 
         // CHANGELOG.md should have a new active section
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
@@ -383,9 +382,6 @@ describe('releng prepare — glsp-theia-integration', function () {
         // NPM checks
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
         expect(rootPkg.version as string).to.match(/-next$/);
-
-        const lerna = readJson(path.join(repoDir, 'lerna.json'));
-        expect(lerna.version as string).to.match(/-next$/);
 
         // Theia README compatibility table should contain 'next'
         const readme = readText(path.join(repoDir, 'README.md'));

--- a/dev-packages/cli/tests/e2e/releng/version.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/releng/version.e2e.spec.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as YAML from 'yaml';
 import { runCli } from '../../helpers/cli-helper';
 import { shallowClone } from '../../helpers/clone-helper';
 import { cleanupTempDir } from '../../helpers/test-helper';
@@ -76,10 +77,6 @@ for (const repo of NPM_REPOS) {
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
             expect(rootPkg.version).to.equal('99.0.0');
 
-            // lerna.json
-            const lerna = readJson(path.join(repoDir, 'lerna.json'));
-            expect(lerna.version).to.equal('99.0.0');
-
             // At least one workspace package.json updated
             const workspacePkgs = findWorkspacePackageJsons(repoDir);
             expect(workspacePkgs.length).to.be.greaterThan(0);
@@ -94,8 +91,11 @@ for (const repo of NPM_REPOS) {
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
             expect(rootPkg.version as string).to.match(/-next$/);
 
-            const lerna = readJson(path.join(repoDir, 'lerna.json'));
-            expect(lerna.version as string).to.match(/-next$/);
+            // At least one workspace package.json updated
+            const workspacePkgs = findWorkspacePackageJsons(repoDir);
+            expect(workspacePkgs.length).to.be.greaterThan(0);
+            const firstPkg = readJson(workspacePkgs[0]);
+            expect(firstPkg.version as string).to.match(/-next$/);
         });
     });
 }
@@ -171,9 +171,6 @@ describe('releng version — glsp-theia-integration', function () {
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
         expect(rootPkg.version).to.equal('99.0.0');
 
-        const lerna = readJson(path.join(repoDir, 'lerna.json'));
-        expect(lerna.version).to.equal('99.0.0');
-
         const workspacePkgs = findWorkspacePackageJsons(repoDir);
         expect(workspacePkgs.length).to.be.greaterThan(0);
 
@@ -189,8 +186,10 @@ describe('releng version — glsp-theia-integration', function () {
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
         expect(rootPkg.version as string).to.match(/-next$/);
 
-        const lerna = readJson(path.join(repoDir, 'lerna.json'));
-        expect(lerna.version as string).to.match(/-next$/);
+        const workspacePkgs = findWorkspacePackageJsons(repoDir);
+        expect(workspacePkgs.length).to.be.greaterThan(0);
+        const firstPkg = readJson(workspacePkgs[0]);
+        expect(firstPkg.version as string).to.match(/-next$/);
     });
 });
 
@@ -289,17 +288,25 @@ describe('releng version — glsp-eclipse-integration', function () {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Finds workspace package.json files (not the root) by reading the root
- * package.json workspaces globs and resolving them.
+ * Reads the workspace package globs of a repo. pnpm repos declare them in `pnpm-workspace.yaml`;
+ * legacy repos use the `workspaces` field in the root `package.json`.
+ */
+function readWorkspaceGlobs(repoDir: string): string[] {
+    const pnpmWorkspace = path.join(repoDir, 'pnpm-workspace.yaml');
+    if (fs.existsSync(pnpmWorkspace)) {
+        const parsed = YAML.parse(fs.readFileSync(pnpmWorkspace, 'utf8')) as { packages?: string[] };
+        return parsed?.packages ?? [];
+    }
+    const rootPkg = readJson(path.join(repoDir, 'package.json'));
+    return Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : ((rootPkg.workspaces as { packages?: string[] })?.packages ?? []);
+}
+
+/**
+ * Finds workspace package.json files (not the root) by resolving the workspace globs.
  */
 function findWorkspacePackageJsons(repoDir: string): string[] {
-    const rootPkg = readJson(path.join(repoDir, 'package.json'));
-    const workspaces: string[] = Array.isArray(rootPkg.workspaces)
-        ? rootPkg.workspaces
-        : ((rootPkg.workspaces as { packages?: string[] })?.packages ?? []);
-
     const results: string[] = [];
-    for (const pattern of workspaces) {
+    for (const pattern of readWorkspaceGlobs(repoDir)) {
         // Expand simple glob patterns like "packages/*"
         const base = pattern.replace(/\/?\*.*$/, '');
         const fullBase = path.join(repoDir, base);

--- a/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
@@ -17,9 +17,19 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as YAML from 'yaml';
 import { cliDiag, runCli } from '../../helpers/cli-helper';
 import { readJson } from '../../helpers/repo-helper';
 import { cleanupTempDir, createTempDir } from '../../helpers/test-helper';
+
+function readOverrides(repoDir: string): Record<string, string> {
+    const yamlPath = path.join(repoDir, 'pnpm-workspace.yaml');
+    if (!fs.existsSync(yamlPath)) {
+        return {};
+    }
+    const parsed = YAML.parse(fs.readFileSync(yamlPath, 'utf8')) as { overrides?: Record<string, string> };
+    return parsed?.overrides ?? {};
+}
 
 describe('repo commands — core (build)', function () {
     const CORE_REPOS = ['glsp-client', 'glsp-server-node'] as const;
@@ -75,7 +85,7 @@ describe('repo commands — core (build)', function () {
     // ── Run ───────────────────────────────────────────────────────────────
 
     describe('run', function () {
-        it('should run a yarn script in a repo via scoped command', function () {
+        it('should run a package script in a repo via scoped command', function () {
             const result = runCli(['repo', 'glsp-client', 'run', '--version', '-d', workDir]);
             expect(result.exitCode, cliDiag(result)).to.equal(0);
         });
@@ -143,15 +153,25 @@ describe('repo commands — core (build)', function () {
     // ── Link / Unlink ──────────────────────────────────────────────────────
 
     describe('link', function () {
-        it('should link core repos', function () {
+        it('should link core repos via pnpm-workspace.yaml overrides', function () {
             const result = runCli(['repo', 'link', '-d', workDir]);
             expect(result.exitCode, cliDiag(result)).to.equal(0);
 
-            const linkDir = path.join(workDir, '.yarn-link');
-            expect(fs.existsSync(linkDir), '.yarn-link directory should exist').to.be.true;
+            // glsp-server-node should consume glsp-client's packages/singletons through link: overrides.
+            const serverDir = path.join(workDir, 'glsp-server-node');
+            const links = Object.entries(readOverrides(serverDir)).filter(([, value]) => value.startsWith('link:'));
+            expect(links.length, 'expected link: overrides in glsp-server-node').to.be.greaterThan(0);
+            expect(
+                links.some(([, value]) => value.includes('glsp-client')),
+                'expected at least one override pointing into glsp-client'
+            ).to.be.true;
 
-            const linkedPkgs = fs.readdirSync(path.join(linkDir, '@eclipse-glsp'));
-            expect(linkedPkgs.length).to.be.greaterThan(0);
+            // A consumed override should resolve to the local glsp-client checkout.
+            const consumed = links.find(([name]) => fs.existsSync(path.join(serverDir, 'node_modules', name)));
+            if (consumed) {
+                const real = fs.realpathSync(path.join(serverDir, 'node_modules', consumed[0]));
+                expect(real.startsWith(fs.realpathSync(path.join(workDir, 'glsp-client')))).to.be.true;
+            }
         });
     });
 
@@ -159,6 +179,9 @@ describe('repo commands — core (build)', function () {
         it('should unlink core repos', function () {
             const result = runCli(['repo', 'unlink', '-d', workDir]);
             expect(result.exitCode, cliDiag(result)).to.equal(0);
+
+            const links = Object.values(readOverrides(path.join(workDir, 'glsp-server-node'))).filter(value => value.startsWith('link:'));
+            expect(links.length, 'link overrides should be removed after unlink').to.equal(0);
         });
     });
 

--- a/dev-packages/cli/tests/e2e/update-next.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/update-next.e2e.spec.ts
@@ -51,8 +51,8 @@ describe('updateNext e2e', () => {
     it('should show debug output with --verbose', () => {
         const pkgPath = path.join(repoDir, 'package.json');
         fs.writeFileSync(pkgPath, JSON.stringify({ name: 'test', version: '1.0.0', private: true, workspaces: [] }, undefined, 2));
-        // updateNext detects the package manager from the repo; mark it as a yarn workspace
-        fs.writeFileSync(path.join(repoDir, 'yarn.lock'), '');
+        // updateNext scans the pnpm workspace; provide a minimal pnpm-workspace.yaml
+        fs.writeFileSync(path.join(repoDir, 'pnpm-workspace.yaml'), 'packages: []\n');
         execSync('git add . && git commit -m "add package.json"', { cwd: repoDir });
         const result = runCli(['updateNext', repoDir, '--verbose']);
         const output = result.stdout + result.stderr;

--- a/dev-packages/cli/tests/helpers/git-helper.ts
+++ b/dev-packages/cli/tests/helpers/git-helper.ts
@@ -35,52 +35,11 @@ export function createTempGitRepo(): string {
     return dir;
 }
 
-/**
- * Creates a temporary yarn monorepo with git, a root package.json with workspaces,
- * and the specified sub-packages (each with their own package.json).
- */
-export function createTempMonorepo(packages: string[] = ['packages/pkg-a']): string {
-    const dir = createTempGitRepo();
-    const rootPkg = {
-        name: 'test-monorepo',
-        version: '1.0.0',
-        private: true,
-        workspaces: ['packages/*']
-    };
-    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(rootPkg, undefined, 2));
-
-    for (const pkg of packages) {
-        const pkgDir = path.join(dir, pkg);
-        fs.mkdirSync(pkgDir, { recursive: true });
-        const pkgName = `@test/${path.basename(pkg)}`;
-        fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version: '1.0.0' }, undefined, 2));
-    }
-
-    git('add .', dir);
-    git('commit -m "add monorepo structure"', dir);
-    return dir;
-}
-
-/** Creates a local bare repo and sets it as origin for the given repo. Returns the bare repo path. */
-export function addLocalBareRemote(repoDir: string): string {
-    const bareDir = createTempDir();
-    git('init --bare', bareDir);
-    git(`remote add origin ${bareDir}`, repoDir);
-    git('push -u origin HEAD', repoDir);
-    return bareDir;
-}
-
 /** Write a file, stage it, and commit. */
 export function commitFile(repoDir: string, relativePath: string, content: string, message: string): void {
     const filePath = path.join(repoDir, relativePath);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, content);
-    git('add .', repoDir);
-    git(`commit -m "${message}"`, repoDir);
-}
-
-/** Stage all changes and commit. */
-export function commitAll(repoDir: string, message: string): void {
     git('add .', repoDir);
     git(`commit -m "${message}"`, repoDir);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
 
   dev-packages/cli:
     devDependencies:
-      '@eclipse-glsp/config':
-        specifier: workspace:*
-        version: link:../config
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Reworks `glsp repo link` onto pnpm and removes the remaining lerna/yarn-era code paths from the CLI after the pnpm migration.

- Rework `repo link`/`unlink` to inject `link:` overrides into each consumer's `pnpm-workspace.yaml` (dependency-ordered), sharing the singleton peers (`sprotty`, `sprotty-protocol`, `vscode-jsonrpc`, `inversify`) from `glsp-client` so they resolve to a single instance across the link.
- Build each linked repo so the overrides resolve to compiled `lib/` output instead of empty source dirs (pnpm does not run yarn's `prepare`-on-install); `--no-build` skips it, `--electron` picks the Theia target.
- Do not link `reflect-metadata`: v0.2+ shares one registry on the global `Reflect` so multiple copies interoperate, and overriding it broke the linked build's `types: ['reflect-metadata']` resolution (TS2688).
- Support linking `glsp-eclipse-integration`, whose pnpm workspace lives in a `client/` subdirectory; the link build covers only the npm side and leaves the Maven server to a separate build.
- Remove lerna/yarn-era leftovers: the lerna publish fallback, the `lerna.json` version update, the yarn `updateNext` path and the `PackageManager` auto-detection; align the releng e2e specs and CLI README with the pnpm reality.

Part of: eclipse-glsp/glsp#1636

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

```bash
pnpm install && pnpm build && pnpm test    # 395 unit tests
```

Cross-repo linking (requires sibling clones; pick a preset):

```bash
glsp repo clone --preset theia    # or vscode / eclipse
glsp repo link  --preset theia    # clones are linked + built in dependency order
glsp repo unlink --preset theia   # restores pnpm-workspace.yaml byte-for-byte
```

Verified locally:

- [x] `pnpm build` + 395 unit tests green
- [x] theia / vscode / eclipse presets: clone → link → build → unlink round-trip clean
- [x] Theia app runs against the linked stack (`pnpm browser start`); the GLSP server launches from the linked source
- [x] `inversify` resolves to a single instance across all linked boundaries; `reflect-metadata` is not overridden
- [x] eclipse links via its `client/` workspace with no Maven invocation

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- A `glsp repo watch` command (running `tsc -b -w` across the linked upstream repos) would give live auto-pickup of source changes; investigated but not implemented here.
- The `glsp-eclipse-integration` and `glsp-vscode-integration` pnpm migrations are still on unmerged branches; linking those presets requires them on the default branch.

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
