### PR TITLE
GLSP-1635: Migrate spec assertions to native Vitest matchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@ lib
 dist
 tsconfig.tsbuildinfo
 eslint.xml
-ctrf/
 coverage/
-.nyc_output/
 
 # Agent specific files
 .claude/plans

--- a/dev-packages/cli/src/cli.spec.ts
+++ b/dev-packages/cli/src/cli.spec.ts
@@ -30,12 +30,12 @@ const optionLongs = (cmd: Command): string[] => cmd.options.map(o => o.long!);
 const subcommandNames = (cmd: Command): string[] => cmd.commands.map(c => c.name());
 const findSub = (parent: Command, name: string): Command => {
     const sub = parent.commands.find(c => c.name() === name);
-    expect(sub, `subcommand '${name}' not found on '${parent.name()}'`).to.exist;
+    expect(sub, `subcommand '${name}' not found on '${parent.name()}'`).toBeDefined();
     return sub!;
 };
 const choices = (cmd: Command, long: string): string[] | undefined => {
     const opt = cmd.options.find(o => o.long === long);
-    expect(opt, `option '${long}' not found on '${cmd.name()}'`).to.exist;
+    expect(opt, `option '${long}' not found on '${cmd.name()}'`).toBeDefined();
     return opt!.argChoices;
 };
 
@@ -47,63 +47,67 @@ describe('cli', () => {
     describe('top-level commands', () => {
         describe('checkHeaders', () => {
             it('should accept a <rootDir> argument', () => {
-                expect(CheckHeaderCommand.registeredArguments).to.have.lengthOf(1);
-                expect(CheckHeaderCommand.registeredArguments[0].name()).to.equal('rootDir');
-                expect(CheckHeaderCommand.registeredArguments[0].required).to.be.true;
+                expect(CheckHeaderCommand.registeredArguments).toHaveLength(1);
+                expect(CheckHeaderCommand.registeredArguments[0].name()).toBe('rootDir');
+                expect(CheckHeaderCommand.registeredArguments[0].required).toBe(true);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(CheckHeaderCommand)).to.include.members([
-                    '--type',
-                    '--fileExtensions',
-                    '--exclude',
-                    '--no-exclude-defaults',
-                    '--json',
-                    '--autoFix',
-                    '--commit'
-                ]);
+                expect(optionLongs(CheckHeaderCommand)).toEqual(
+                    expect.arrayContaining([
+                        '--type',
+                        '--fileExtensions',
+                        '--exclude',
+                        '--no-exclude-defaults',
+                        '--json',
+                        '--autoFix',
+                        '--commit'
+                    ])
+                );
             });
 
             it('should restrict --type choices', () => {
-                expect(choices(CheckHeaderCommand, '--type')).to.deep.equal(['full', 'changes', 'lastCommit']);
+                expect(choices(CheckHeaderCommand, '--type')).toEqual(['full', 'changes', 'lastCommit']);
             });
         });
 
         describe('updateNext', () => {
             it('should have alias "u"', () => {
-                expect(UpdateNextCommand.alias()).to.equal('u');
+                expect(UpdateNextCommand.alias()).toBe('u');
             });
 
             it('should accept an optional [rootDir] argument', () => {
-                expect(UpdateNextCommand.registeredArguments).to.have.lengthOf(1);
-                expect(UpdateNextCommand.registeredArguments[0].required).to.be.false;
+                expect(UpdateNextCommand.registeredArguments).toHaveLength(1);
+                expect(UpdateNextCommand.registeredArguments[0].required).toBe(false);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(UpdateNextCommand)).to.include.members(['--verbose']);
+                expect(optionLongs(UpdateNextCommand)).toEqual(expect.arrayContaining(['--verbose']));
             });
         });
 
         describe('generateIndex', () => {
             it('should accept a variadic <rootDir...> argument', () => {
-                expect(GenerateIndex.registeredArguments).to.have.lengthOf(1);
-                expect(GenerateIndex.registeredArguments[0].variadic).to.be.true;
+                expect(GenerateIndex.registeredArguments).toHaveLength(1);
+                expect(GenerateIndex.registeredArguments[0].variadic).toBe(true);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(GenerateIndex)).to.include.members([
-                    '--singleIndex',
-                    '--forceOverwrite',
-                    '--match',
-                    '--ignore',
-                    '--style',
-                    '--ignoreFile',
-                    '--verbose'
-                ]);
+                expect(optionLongs(GenerateIndex)).toEqual(
+                    expect.arrayContaining([
+                        '--singleIndex',
+                        '--forceOverwrite',
+                        '--match',
+                        '--ignore',
+                        '--style',
+                        '--ignoreFile',
+                        '--verbose'
+                    ])
+                );
             });
 
             it('should restrict --style choices', () => {
-                expect(choices(GenerateIndex, '--style')).to.deep.equal(['commonjs', 'esm']);
+                expect(choices(GenerateIndex, '--style')).toEqual(['commonjs', 'esm']);
             });
         });
     });
@@ -112,7 +116,7 @@ describe('cli', () => {
 
     describe('releng', () => {
         it('should have version and prepare subcommands', () => {
-            expect(subcommandNames(RelengCommand)).to.include.members(['version', 'prepare']);
+            expect(subcommandNames(RelengCommand)).toEqual(expect.arrayContaining(['version', 'prepare']));
         });
 
         describe('version', () => {
@@ -120,18 +124,18 @@ describe('cli', () => {
 
             it('should accept <versionType> argument with choices', () => {
                 const arg = cmd.registeredArguments[0];
-                expect(arg.name()).to.equal('versionType');
-                expect(arg.required).to.be.true;
-                expect(arg.argChoices).to.deep.equal(['major', 'minor', 'patch', 'custom', 'next']);
+                expect(arg.name()).toBe('versionType');
+                expect(arg.required).toBe(true);
+                expect(arg.argChoices).toEqual(['major', 'minor', 'patch', 'custom', 'next']);
             });
 
             it('should accept optional [customVersion] argument', () => {
-                expect(cmd.registeredArguments[1].name()).to.equal('customVersion');
-                expect(cmd.registeredArguments[1].required).to.be.false;
+                expect(cmd.registeredArguments[1].name()).toBe('customVersion');
+                expect(cmd.registeredArguments[1].required).toBe(false);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--verbose', '--repoDir']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--verbose', '--repoDir']));
             });
         });
 
@@ -140,11 +144,11 @@ describe('cli', () => {
 
             it('should accept <versionType> argument with choices', () => {
                 const arg = cmd.registeredArguments[0];
-                expect(arg.argChoices).to.deep.equal(['major', 'minor', 'patch', 'custom', 'next']);
+                expect(arg.argChoices).toEqual(['major', 'minor', 'patch', 'custom', 'next']);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--verbose', '--repoDir', '--no-push', '--draft', '--no-check']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--verbose', '--repoDir', '--no-push', '--draft', '--no-check']));
             });
         });
     });
@@ -153,60 +157,57 @@ describe('cli', () => {
 
     describe('repo', () => {
         it('should register all top-level repo subcommands', () => {
-            expect(subcommandNames(RepoCommand)).to.include.members([
-                'clone',
-                'fork',
-                'build',
-                'link',
-                'unlink',
-                'pwd',
-                'log',
-                'workspace'
-            ]);
+            expect(subcommandNames(RepoCommand)).toEqual(
+                expect.arrayContaining(['clone', 'fork', 'build', 'link', 'unlink', 'pwd', 'log', 'workspace'])
+            );
         });
 
         it('should register a subrepo command for each GLSPRepo', () => {
             for (const repoName of GLSPRepo.choices) {
-                expect(subcommandNames(RepoCommand), `subrepo '${repoName}' should be registered`).to.include(repoName);
+                expect(subcommandNames(RepoCommand), `subrepo '${repoName}' should be registered`).toContain(repoName);
             }
         });
 
         it('should have a global --dir option', () => {
-            expect(optionLongs(RepoCommand)).to.include('--dir');
+            expect(optionLongs(RepoCommand)).toContain('--dir');
         });
 
         describe('clone', () => {
             const cmd = findSub(RepoCommand, 'clone');
 
             it('should accept optional [repos...] argument', () => {
-                expect(cmd.registeredArguments[0].variadic).to.be.true;
-                expect(cmd.registeredArguments[0].required).to.be.false;
+                expect(cmd.registeredArguments[0].variadic).toBe(true);
+                expect(cmd.registeredArguments[0].required).toBe(false);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members([
-                    '--dir',
-                    '--protocol',
-                    '--branch',
-                    '--fork',
-                    '--override',
-                    '--preset',
-                    '--interactive',
-                    '--no-fail-fast',
-                    '--verbose'
-                ]);
+                expect(optionLongs(cmd)).toEqual(
+                    expect.arrayContaining([
+                        '--dir',
+                        '--protocol',
+                        '--branch',
+                        '--fork',
+                        '--override',
+                        '--preset',
+                        '--interactive',
+                        '--no-fail-fast',
+                        '--verbose'
+                    ])
+                );
             });
 
             it('should restrict --protocol choices', () => {
-                expect(choices(cmd, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+                expect(choices(cmd, '--protocol')).toEqual(['ssh', 'https', 'gh']);
             });
 
             it('should restrict --override choices', () => {
-                expect(choices(cmd, '--override')).to.deep.equal(['rename', 'remove']);
+                expect(choices(cmd, '--override')).toEqual(['rename', 'remove']);
             });
 
             it('should restrict --preset choices', () => {
-                expect(choices(cmd, '--preset')).to.include.members(['core', 'theia', 'vscode', 'eclipse', 'playwright', 'all']);
+                expect(choices(cmd, '--preset')).toEqual(
+                    expect.arrayContaining(['core', 'theia', 'vscode', 'eclipse', 'playwright', 'all'])
+                );
             });
         });
 
@@ -214,16 +215,16 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'fork');
 
             it('should accept required <user> argument', () => {
-                expect(cmd.registeredArguments[0].name()).to.equal('user');
-                expect(cmd.registeredArguments[0].required).to.be.true;
+                expect(cmd.registeredArguments[0].name()).toBe('user');
+                expect(cmd.registeredArguments[0].required).toBe(true);
             });
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--dir', '--protocol', '--repo', '--preset', '--verbose']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--protocol', '--repo', '--preset', '--verbose']));
             });
 
             it('should restrict --protocol choices', () => {
-                expect(choices(cmd, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+                expect(choices(cmd, '--protocol')).toEqual(['ssh', 'https', 'gh']);
             });
         });
 
@@ -231,15 +232,9 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'build');
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members([
-                    '--dir',
-                    '--repo',
-                    '--preset',
-                    '--electron',
-                    '--no-java',
-                    '--no-fail-fast',
-                    '--verbose'
-                ]);
+                expect(optionLongs(cmd)).toEqual(
+                    expect.arrayContaining(['--dir', '--repo', '--preset', '--electron', '--no-java', '--no-fail-fast', '--verbose'])
+                );
             });
         });
 
@@ -247,7 +242,7 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'link');
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']));
             });
         });
 
@@ -255,7 +250,7 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'unlink');
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--repo', '--preset', '--no-fail-fast', '--verbose']));
             });
         });
 
@@ -263,7 +258,7 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'pwd');
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--dir', '--raw', '--verbose']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--raw', '--verbose']));
             });
         });
 
@@ -271,7 +266,7 @@ describe('cli', () => {
             const cmd = findSub(RepoCommand, 'log');
 
             it('should have expected options', () => {
-                expect(optionLongs(cmd)).to.include.members(['--dir', '--repo', '--preset', '--verbose']);
+                expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--repo', '--preset', '--verbose']));
             });
         });
 
@@ -279,14 +274,14 @@ describe('cli', () => {
             const workspace = findSub(RepoCommand, 'workspace');
 
             it('should have init and open subcommands', () => {
-                expect(subcommandNames(workspace)).to.include.members(['init', 'open']);
+                expect(subcommandNames(workspace)).toEqual(expect.arrayContaining(['init', 'open']));
             });
 
             describe('init', () => {
                 const cmd = findSub(workspace, 'init');
 
                 it('should have expected options', () => {
-                    expect(optionLongs(cmd)).to.include.members(['--dir', '--output', '--repo', '--preset', '--verbose']);
+                    expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--output', '--repo', '--preset', '--verbose']));
                 });
             });
 
@@ -294,7 +289,7 @@ describe('cli', () => {
                 const cmd = findSub(workspace, 'open');
 
                 it('should have expected options', () => {
-                    expect(optionLongs(cmd)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(cmd)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
             });
         });
@@ -317,12 +312,12 @@ describe('cli', () => {
                     const cmd = createSubrepoCommand(repoName);
 
                     it('should have common subcommands', () => {
-                        expect(subcommandNames(cmd)).to.include.members(['clone', 'switch', 'build', 'pwd', 'log', 'run']);
+                        expect(subcommandNames(cmd)).toEqual(expect.arrayContaining(['clone', 'switch', 'build', 'pwd', 'log', 'run']));
                     });
 
                     if (SHORT_ALIASES[repoName]) {
                         it(`should have alias "${SHORT_ALIASES[repoName]}"`, () => {
-                            expect(cmd.alias()).to.equal(SHORT_ALIASES[repoName]);
+                            expect(cmd.alias()).toBe(SHORT_ALIASES[repoName]);
                         });
                     }
 
@@ -330,22 +325,17 @@ describe('cli', () => {
                         const clone = findSub(cmd, 'clone');
 
                         it('should have expected options', () => {
-                            expect(optionLongs(clone)).to.include.members([
-                                '--dir',
-                                '--protocol',
-                                '--branch',
-                                '--fork',
-                                '--override',
-                                '--verbose'
-                            ]);
+                            expect(optionLongs(clone)).toEqual(
+                                expect.arrayContaining(['--dir', '--protocol', '--branch', '--fork', '--override', '--verbose'])
+                            );
                         });
 
                         it('should restrict --protocol choices', () => {
-                            expect(choices(clone, '--protocol')).to.deep.equal(['ssh', 'https', 'gh']);
+                            expect(choices(clone, '--protocol')).toEqual(['ssh', 'https', 'gh']);
                         });
 
                         it('should restrict --override choices', () => {
-                            expect(choices(clone, '--override')).to.deep.equal(['rename', 'remove']);
+                            expect(choices(clone, '--override')).toEqual(['rename', 'remove']);
                         });
                     });
 
@@ -353,7 +343,7 @@ describe('cli', () => {
                         const sw = findSub(cmd, 'switch');
 
                         it('should have expected options', () => {
-                            expect(optionLongs(sw)).to.include.members(['--branch', '--dir', '--pr', '--force', '--verbose']);
+                            expect(optionLongs(sw)).toEqual(expect.arrayContaining(['--branch', '--dir', '--pr', '--force', '--verbose']));
                         });
                     });
 
@@ -361,12 +351,12 @@ describe('cli', () => {
                         const build = findSub(cmd, 'build');
 
                         it('should have expected options', () => {
-                            expect(optionLongs(build)).to.include.members(['--dir', '--verbose']);
+                            expect(optionLongs(build)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                         });
 
                         if (repoName === 'glsp-theia-integration') {
                             it('should have --electron option', () => {
-                                expect(optionLongs(build)).to.include('--electron');
+                                expect(optionLongs(build)).toContain('--electron');
                             });
                         }
                     });
@@ -375,7 +365,7 @@ describe('cli', () => {
                         const pwd = findSub(cmd, 'pwd');
 
                         it('should have expected options', () => {
-                            expect(optionLongs(pwd)).to.include.members(['--dir', '--verbose']);
+                            expect(optionLongs(pwd)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                         });
                     });
 
@@ -383,7 +373,7 @@ describe('cli', () => {
                         const log = findSub(cmd, 'log');
 
                         it('should have expected options', () => {
-                            expect(optionLongs(log)).to.include.members(['--dir', '--verbose']);
+                            expect(optionLongs(log)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                         });
                     });
 
@@ -391,13 +381,13 @@ describe('cli', () => {
                         const run = findSub(cmd, 'run');
 
                         it('should accept a required <script> argument', () => {
-                            expect(run.registeredArguments).to.have.lengthOf(1);
-                            expect(run.registeredArguments[0].name()).to.equal('script');
-                            expect(run.registeredArguments[0].required).to.be.true;
+                            expect(run.registeredArguments).toHaveLength(1);
+                            expect(run.registeredArguments[0].name()).toBe('script');
+                            expect(run.registeredArguments[0].required).toBe(true);
                         });
 
                         it('should have expected options', () => {
-                            expect(optionLongs(run)).to.include.members(['--dir', '--verbose']);
+                            expect(optionLongs(run)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                         });
                     });
                 });
@@ -410,11 +400,11 @@ describe('cli', () => {
                 const start = findSub(cmd, 'start');
 
                 it('should have start command', () => {
-                    expect(subcommandNames(cmd)).to.include('start');
+                    expect(subcommandNames(cmd)).toContain('start');
                 });
 
                 it('should have expected start options', () => {
-                    expect(optionLongs(start)).to.include.members(['--dir', '--browser', '--dry-run', '--verbose']);
+                    expect(optionLongs(start)).toEqual(expect.arrayContaining(['--dir', '--browser', '--dry-run', '--verbose']));
                 });
             });
 
@@ -423,29 +413,29 @@ describe('cli', () => {
                 const start = findSub(cmd, 'start');
 
                 it('should have start command', () => {
-                    expect(subcommandNames(cmd)).to.include('start');
+                    expect(subcommandNames(cmd)).toContain('start');
                 });
 
                 it('should have expected start options', () => {
-                    expect(optionLongs(start)).to.include.members(['--dir', '--socket', '--dry-run', '--verbose']);
+                    expect(optionLongs(start)).toEqual(expect.arrayContaining(['--dir', '--socket', '--dry-run', '--verbose']));
                 });
 
                 it('should have browser-bundle command', () => {
-                    expect(subcommandNames(cmd)).to.include('browser-bundle');
+                    expect(subcommandNames(cmd)).toContain('browser-bundle');
                 });
 
                 it('should have expected browser-bundle options', () => {
                     const browserBundle = findSub(cmd, 'browser-bundle');
-                    expect(optionLongs(browserBundle)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(browserBundle)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
 
                 it('should have node-bundle command', () => {
-                    expect(subcommandNames(cmd)).to.include('node-bundle');
+                    expect(subcommandNames(cmd)).toContain('node-bundle');
                 });
 
                 it('should have expected node-bundle options', () => {
                     const nodeBundle = findSub(cmd, 'node-bundle');
-                    expect(optionLongs(nodeBundle)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(nodeBundle)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
             });
 
@@ -454,11 +444,11 @@ describe('cli', () => {
                 const start = findSub(cmd, 'start');
 
                 it('should have start command', () => {
-                    expect(subcommandNames(cmd)).to.include('start');
+                    expect(subcommandNames(cmd)).toContain('start');
                 });
 
                 it('should have expected start options', () => {
-                    expect(optionLongs(start)).to.include.members(['--dir', '--socket', '--dry-run', '--verbose']);
+                    expect(optionLongs(start)).toEqual(expect.arrayContaining(['--dir', '--socket', '--dry-run', '--verbose']));
                 });
             });
 
@@ -466,21 +456,23 @@ describe('cli', () => {
                 const cmd = createSubrepoCommand('glsp-theia-integration');
 
                 it('should have start command', () => {
-                    expect(subcommandNames(cmd)).to.include('start');
+                    expect(subcommandNames(cmd)).toContain('start');
                 });
 
                 it('should have expected start options', () => {
                     const start = findSub(cmd, 'start');
-                    expect(optionLongs(start)).to.include.members(['--dir', '--electron', '--debug', '--dry-run', '--verbose']);
+                    expect(optionLongs(start)).toEqual(
+                        expect.arrayContaining(['--dir', '--electron', '--debug', '--dry-run', '--verbose'])
+                    );
                 });
 
                 it('should have open command', () => {
-                    expect(subcommandNames(cmd)).to.include('open');
+                    expect(subcommandNames(cmd)).toContain('open');
                 });
 
                 it('should have expected open options', () => {
                     const open = findSub(cmd, 'open');
-                    expect(optionLongs(open)).to.include.members(['--verbose']);
+                    expect(optionLongs(open)).toEqual(expect.arrayContaining(['--verbose']));
                 });
             });
 
@@ -488,47 +480,47 @@ describe('cli', () => {
                 const cmd = createSubrepoCommand('glsp-vscode-integration');
 
                 it('should have vsix-id command', () => {
-                    expect(subcommandNames(cmd)).to.include('vsix-id');
+                    expect(subcommandNames(cmd)).toContain('vsix-id');
                 });
 
                 it('should have vsix-path command', () => {
-                    expect(subcommandNames(cmd)).to.include('vsix-path');
+                    expect(subcommandNames(cmd)).toContain('vsix-path');
                 });
 
                 it('should have expected vsix-path options', () => {
                     const vsixPath = findSub(cmd, 'vsix-path');
-                    expect(optionLongs(vsixPath)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(vsixPath)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
 
                 it('should have package command', () => {
-                    expect(subcommandNames(cmd)).to.include('package');
+                    expect(subcommandNames(cmd)).toContain('package');
                 });
 
                 it('should have expected package options', () => {
                     const pkg = findSub(cmd, 'package');
-                    expect(optionLongs(pkg)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(pkg)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
 
                 it('should have web-vsix-id command', () => {
-                    expect(subcommandNames(cmd)).to.include('web-vsix-id');
+                    expect(subcommandNames(cmd)).toContain('web-vsix-id');
                 });
 
                 it('should have web-vsix-path command', () => {
-                    expect(subcommandNames(cmd)).to.include('web-vsix-path');
+                    expect(subcommandNames(cmd)).toContain('web-vsix-path');
                 });
 
                 it('should have expected web-vsix-path options', () => {
                     const webVsixPath = findSub(cmd, 'web-vsix-path');
-                    expect(optionLongs(webVsixPath)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(webVsixPath)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
 
                 it('should have web-package command', () => {
-                    expect(subcommandNames(cmd)).to.include('web-package');
+                    expect(subcommandNames(cmd)).toContain('web-package');
                 });
 
                 it('should have expected web-package options', () => {
                     const webPkg = findSub(cmd, 'web-package');
-                    expect(optionLongs(webPkg)).to.include.members(['--dir', '--verbose']);
+                    expect(optionLongs(webPkg)).toEqual(expect.arrayContaining(['--dir', '--verbose']));
                 });
             });
         });

--- a/dev-packages/cli/src/commands/releng/common.spec.ts
+++ b/dev-packages/cli/src/commands/releng/common.spec.ts
@@ -45,19 +45,19 @@ describe('common', () => {
         it('should derive repo name from HTTPS remote URL', () => {
             vi.spyOn(gitUtil, 'getRemoteUrl').mockReturnValue('https://github.com/eclipse-glsp/glsp-client.git');
             const result = GLSPRepo.deriveFromDirectory('/some/path');
-            expect(result).to.equal('glsp-client');
+            expect(result).toBe('glsp-client');
         });
 
         it('should derive repo name from SSH remote URL', () => {
             vi.spyOn(gitUtil, 'getRemoteUrl').mockReturnValue('git@github.com:eclipse-glsp/glsp-server-node.git');
             const result = GLSPRepo.deriveFromDirectory('/some/path');
-            expect(result).to.equal('glsp-server-node');
+            expect(result).toBe('glsp-server-node');
         });
 
         it('should return undefined for a non-GLSP repository', () => {
             vi.spyOn(gitUtil, 'getRemoteUrl').mockReturnValue('https://github.com/other/repo.git');
             const result = GLSPRepo.deriveFromDirectory('/some/path');
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
     });
 
@@ -65,7 +65,7 @@ describe('common', () => {
         it('should return true when gh is installed and authenticated', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue('');
             const result = isGithubCLIAuthenticated();
-            expect(result).to.be.true;
+            expect(result).toBe(true);
         });
 
         it('should return false when gh auth status throws', () => {
@@ -76,7 +76,7 @@ describe('common', () => {
                 return '';
             });
             const result = isGithubCLIAuthenticated();
-            expect(result).to.be.false;
+            expect(result).toBe(false);
         });
 
         it('should return false when gh is not installed', () => {
@@ -84,7 +84,7 @@ describe('common', () => {
                 throw new Error('gh not found');
             });
             const result = isGithubCLIAuthenticated();
-            expect(result).to.be.false;
+            expect(result).toBe(false);
         });
     });
 
@@ -106,7 +106,7 @@ describe('common', () => {
             } as unknown as PackageHelper;
 
             const result = getGLSPDependencies(pkg);
-            expect(result).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/config']);
+            expect(result).toEqual(['@eclipse-glsp/client', '@eclipse-glsp/config']);
         });
 
         it('should return empty array when dependency sections are missing', () => {
@@ -118,41 +118,41 @@ describe('common', () => {
             } as unknown as PackageHelper;
 
             const result = getGLSPDependencies(pkg);
-            expect(result).to.deep.equal([]);
+            expect(result).toEqual([]);
         });
     });
 
     describe('isNextVersion', () => {
         it('should return true for -next suffix', () => {
-            expect(isNextVersion('1.0.0-next')).to.be.true;
+            expect(isNextVersion('1.0.0-next')).toBe(true);
         });
 
         it('should return true for .SNAPSHOT suffix', () => {
-            expect(isNextVersion('1.0.0.SNAPSHOT')).to.be.true;
+            expect(isNextVersion('1.0.0.SNAPSHOT')).toBe(true);
         });
 
         it('should return false for a release version', () => {
-            expect(isNextVersion('1.0.0')).to.be.false;
+            expect(isNextVersion('1.0.0')).toBe(false);
         });
     });
 
     describe('asMvnVersion', () => {
         it('should convert -next to -SNAPSHOT', () => {
-            expect(asMvnVersion('1.0.0-next')).to.equal('1.0.0-SNAPSHOT');
+            expect(asMvnVersion('1.0.0-next')).toBe('1.0.0-SNAPSHOT');
         });
 
         it('should return release versions unchanged', () => {
-            expect(asMvnVersion('2.3.1')).to.equal('2.3.1');
+            expect(asMvnVersion('2.3.1')).toBe('2.3.1');
         });
     });
 
     describe('VersionType.validate', () => {
         it('should throw when type is custom but no version is provided', () => {
-            expect(() => VersionType.validate('custom')).to.throw(/Custom version must be provided/);
+            expect(() => VersionType.validate('custom')).toThrow(/Custom version must be provided/);
         });
 
         it('should accept custom type with a version', () => {
-            expect(() => VersionType.validate('custom', '1.0.0')).to.not.throw();
+            expect(() => VersionType.validate('custom', '1.0.0')).not.toThrow();
         });
 
         it('should warn when a custom version is provided for non-custom type', () => {
@@ -162,7 +162,7 @@ describe('common', () => {
         });
 
         it('should accept non-custom type without a version', () => {
-            expect(() => VersionType.validate('minor')).to.not.throw();
+            expect(() => VersionType.validate('minor')).not.toThrow();
         });
     });
 
@@ -170,50 +170,50 @@ describe('common', () => {
         it('should return the custom version for npm repos', () => {
             const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
             const result = VersionType.deriveVersion(options, '99.0.0');
-            expect(result).to.equal('99.0.0');
+            expect(result).toBe('99.0.0');
         });
 
         it('should throw for invalid custom version on npm repos', () => {
             const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
-            expect(() => VersionType.deriveVersion(options, 'not-semver')).to.throw(/Not a valid custom version/);
+            expect(() => VersionType.deriveVersion(options, 'not-semver')).toThrow(/Not a valid custom version/);
         });
 
         it('should accept any custom version for java repos', () => {
             const options = { versionType: 'custom' as VersionType, repoDir: '/repo', repo: 'glsp-server' as const, verbose: false };
             const result = VersionType.deriveVersion(options, '2.0.0.qualifier');
-            expect(result).to.equal('2.0.0.qualifier');
+            expect(result).toBe('2.0.0.qualifier');
         });
 
         it('should derive minor version from local package', () => {
             vi.spyOn(packageUtil, 'readPackage').mockReturnValue({ content: { version: '1.2.0' } } as unknown as PackageHelper);
             const options = { versionType: 'minor' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
             const result = VersionType.deriveVersion(options);
-            expect(result).to.equal('1.3.0');
+            expect(result).toBe('1.3.0');
         });
 
         it('should derive next version with -next suffix', () => {
             vi.spyOn(packageUtil, 'readPackage').mockReturnValue({ content: { version: '1.2.0' } } as unknown as PackageHelper);
             const options = { versionType: 'next' as VersionType, repoDir: '/repo', repo: 'glsp-client' as const, verbose: false };
             const result = VersionType.deriveVersion(options);
-            expect(result).to.equal('1.3.0-next');
+            expect(result).toBe('1.3.0-next');
         });
     });
 
     describe('getLocalVersion', () => {
         it('should read from pom.xml for glsp-server', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue('<version>2.0.0</version>');
-            expect(getLocalVersion('/repo', 'glsp-server')).to.equal('2.0.0');
+            expect(getLocalVersion('/repo', 'glsp-server')).toBe('2.0.0');
         });
 
         it('should read from server/pom.xml for glsp-eclipse-integration', () => {
             const readStub = vi.spyOn(fileUtil, 'readFile').mockReturnValue('<version>2.1.0</version>');
-            expect(getLocalVersion('/repo', 'glsp-eclipse-integration')).to.equal('2.1.0');
-            expect(readStub.mock.calls[0][0]).to.contain('server');
+            expect(getLocalVersion('/repo', 'glsp-eclipse-integration')).toBe('2.1.0');
+            expect(readStub.mock.calls[0][0]).toContain('server');
         });
 
         it('should read from package.json for npm repos', () => {
             vi.spyOn(packageUtil, 'readPackage').mockReturnValue({ content: { version: '1.5.0' } } as unknown as PackageHelper);
-            expect(getLocalVersion('/repo', 'glsp-client')).to.equal('1.5.0');
+            expect(getLocalVersion('/repo', 'glsp-client')).toBe('1.5.0');
         });
     });
 
@@ -226,46 +226,46 @@ describe('common', () => {
   <version>2.7.0-SNAPSHOT</version>
 </project>`
             );
-            expect(getVersionFromPom('/repo')).to.equal('2.7.0-SNAPSHOT');
+            expect(getVersionFromPom('/repo')).toBe('2.7.0-SNAPSHOT');
         });
 
         it('should throw when no version is found', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue('<project></project>');
-            expect(() => getVersionFromPom('/repo')).to.throw(/Could not find version/);
+            expect(() => getVersionFromPom('/repo')).toThrow(/Could not find version/);
         });
     });
 
     describe('getVersionFromPackage', () => {
         it('should return the version from package.json', () => {
             vi.spyOn(packageUtil, 'readPackage').mockReturnValue({ content: { version: '1.0.0' } } as unknown as PackageHelper);
-            expect(getVersionFromPackage('/repo')).to.equal('1.0.0');
+            expect(getVersionFromPackage('/repo')).toBe('1.0.0');
         });
 
         it('should throw when no version is found', () => {
             vi.spyOn(packageUtil, 'readPackage').mockReturnValue({ content: {} } as unknown as PackageHelper);
-            expect(() => getVersionFromPackage('/repo')).to.throw(/No version found/);
+            expect(() => getVersionFromPackage('/repo')).toThrow(/No version found/);
         });
     });
 
     describe('getLastReleaseTag', () => {
         it('should return the first valid semver tag starting with v', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue('v2.0.0\nv1.0.0\nsome-tag');
-            expect(getLastReleaseTag('/repo')).to.equal('v2.0.0');
+            expect(getLastReleaseTag('/repo')).toBe('v2.0.0');
         });
 
         it('should skip pre-release tags', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue('v2.0.0-rc.1\nv1.0.0');
-            expect(getLastReleaseTag('/repo')).to.equal('v1.0.0');
+            expect(getLastReleaseTag('/repo')).toBe('v1.0.0');
         });
 
         it('should skip tags without v prefix', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue('release-1.0\nv0.9.0');
-            expect(getLastReleaseTag('/repo')).to.equal('v0.9.0');
+            expect(getLastReleaseTag('/repo')).toBe('v0.9.0');
         });
 
         it('should return undefined when no valid tag exists', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue('nightly\nsome-tag');
-            expect(getLastReleaseTag('/repo')).to.be.undefined;
+            expect(getLastReleaseTag('/repo')).toBeUndefined();
         });
     });
 
@@ -289,23 +289,23 @@ describe('common', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue(changelogContent);
             vi.spyOn(processUtil, 'exec').mockReturnValue('v1.0.0');
             const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
-            expect(result).to.contain('Added feature A');
-            expect(result).to.contain('Added feature B');
-            expect(result).to.not.contain('Initial release');
+            expect(result).toContain('Added feature A');
+            expect(result).toContain('Added feature B');
+            expect(result).not.toContain('Initial release');
         });
 
         it('should append a full changelog link when a previous tag exists', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue(changelogContent);
             vi.spyOn(processUtil, 'exec').mockReturnValue('v1.0.0');
             const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
-            expect(result).to.contain('Full Changelog');
-            expect(result).to.contain('v1.0.0...v2.0.0');
+            expect(result).toContain('Full Changelog');
+            expect(result).toContain('v1.0.0...v2.0.0');
         });
 
         it('should throw when no section matches the version', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue(changelogContent);
             vi.spyOn(processUtil, 'exec').mockReturnValue('');
-            expect(() => getChangeLogChanges({ repoDir: '/repo', version: '9.9.9', repo: 'glsp-client' })).to.throw(
+            expect(() => getChangeLogChanges({ repoDir: '/repo', version: '9.9.9', repo: 'glsp-client' })).toThrow(
                 /No changelog section found/
             );
         });
@@ -314,8 +314,8 @@ describe('common', () => {
             vi.spyOn(fileUtil, 'readFile').mockReturnValue(changelogContent);
             vi.spyOn(processUtil, 'exec').mockReturnValue('');
             const result = getChangeLogChanges({ repoDir: '/repo', version: '2.0.0', repo: 'glsp-client' });
-            expect(result).to.contain('## Features');
-            expect(result).to.not.contain('### Features');
+            expect(result).toContain('## Features');
+            expect(result).not.toContain('### Features');
         });
     });
 });

--- a/dev-packages/cli/src/commands/releng/publish.spec.ts
+++ b/dev-packages/cli/src/commands/releng/publish.spec.ts
@@ -73,7 +73,7 @@ describe('releng publish', () => {
             createRootPackage('2.8.0-next');
             stubGit('v2.7.0', '42');
             const canary = deriveCanaryVersion(tempDir);
-            expect(canary).to.deep.equal({ base: '2.8.0-next', lastTag: 'v2.7.0', commitCount: 42, version: '2.8.0-next.42' });
+            expect(canary).toEqual({ base: '2.8.0-next', lastTag: 'v2.7.0', commitCount: 42, version: '2.8.0-next.42' });
         });
 
         it('should throw a helpful error when no git tag can be found', () => {
@@ -84,7 +84,7 @@ describe('releng publish', () => {
                 }
                 return undefined;
             });
-            expect(() => deriveCanaryVersion(tempDir)).to.throw(/fetch-depth: 0/);
+            expect(() => deriveCanaryVersion(tempDir)).toThrow(/fetch-depth: 0/);
         });
     });
 
@@ -100,15 +100,15 @@ describe('releng publish', () => {
 
             const writtenA = JSON.parse(fs.readFileSync(pkgA.filePath, 'utf8'));
             const writtenB = JSON.parse(fs.readFileSync(pkgB.filePath, 'utf8'));
-            expect(writtenA.version).to.equal('2.8.0-next.42');
-            expect(writtenB.version).to.equal('2.8.0-next.42');
+            expect(writtenA.version).toBe('2.8.0-next.42');
+            expect(writtenB.version).toBe('2.8.0-next.42');
             // the root package keeps the plain base version
             const root = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf8'));
-            expect(root.version).to.equal('2.8.0-next');
+            expect(root.version).toBe('2.8.0-next');
 
             expect(execAsyncStub).toHaveBeenCalledOnce();
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm publish -r --tag next --no-git-checks --report-summary');
-            expect(execAsyncStub.mock.calls[0][1].cwd).to.equal(tempDir);
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm publish -r --tag next --no-git-checks --report-summary');
+            expect(execAsyncStub.mock.calls[0][1].cwd).toBe(tempDir);
         });
 
         it('should not write versions and pass --dry-run in dry-run mode', async () => {
@@ -120,8 +120,8 @@ describe('releng publish', () => {
             await publish('next', makeOptions({ dryRun: true }));
 
             const writtenA = JSON.parse(fs.readFileSync(pkgA.filePath, 'utf8'));
-            expect(writtenA.version).to.equal('2.8.0-next');
-            expect(execAsyncStub.mock.calls[0][0]).to.contain('--dry-run');
+            expect(writtenA.version).toBe('2.8.0-next');
+            expect(execAsyncStub.mock.calls[0][0]).toContain('--dry-run');
         });
 
         it('should pass a custom registry to pnpm publish', async () => {
@@ -131,7 +131,7 @@ describe('releng publish', () => {
 
             await publish('next', makeOptions({ registry: 'http://localhost:4873' }));
 
-            expect(execAsyncStub.mock.calls[0][0]).to.contain('--registry http://localhost:4873');
+            expect(execAsyncStub.mock.calls[0][0]).toContain('--registry http://localhost:4873');
         });
 
         it('should bump versions and print the publish command without publishing in interactive mode', async () => {
@@ -144,10 +144,10 @@ describe('releng publish', () => {
             await publish('next', makeOptions({ interactive: true }));
 
             // versions are still bumped on disk
-            expect(JSON.parse(fs.readFileSync(pkgA.filePath, 'utf8')).version).to.equal('2.8.0-next.42');
+            expect(JSON.parse(fs.readFileSync(pkgA.filePath, 'utf8')).version).toBe('2.8.0-next.42');
             // but nothing is published
             expect(execAsyncStub).not.toHaveBeenCalled();
-            expect(infoStub.mock.calls.flat()).to.contain('\n  pnpm publish -r --tag next --no-git-checks\n');
+            expect(infoStub.mock.calls.flat()).toContain('\n  pnpm publish -r --tag next --no-git-checks\n');
         });
 
         it('should refuse to publish a canary if the root version is not a next version', async () => {
@@ -157,7 +157,7 @@ describe('releng publish', () => {
                 await publish('next', makeOptions());
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain('not a next version');
+                expect((error as Error).message).toContain('not a next version');
             }
         });
     });
@@ -169,7 +169,7 @@ describe('releng publish', () => {
                 await publish('latest', makeOptions());
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain("Refusing to publish under the 'latest' dist-tag");
+                expect((error as Error).message).toContain("Refusing to publish under the 'latest' dist-tag");
             }
         });
 
@@ -188,7 +188,7 @@ describe('releng publish', () => {
             await publish('latest', makeOptions());
 
             expect(execAsyncStub).toHaveBeenCalledOnce();
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm publish -r --tag latest --no-git-checks --report-summary');
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm publish -r --tag latest --no-git-checks --report-summary');
         });
 
         it('should skip publishing when all package versions already exist', async () => {
@@ -243,7 +243,7 @@ describe('releng publish', () => {
 
             await publish('next', makeOptions());
 
-            expect(fs.existsSync(summaryPath)).to.be.false;
+            expect(fs.existsSync(summaryPath)).toBe(false);
         });
     });
 });

--- a/dev-packages/cli/src/commands/releng/version.spec.ts
+++ b/dev-packages/cli/src/commands/releng/version.spec.ts
@@ -65,8 +65,8 @@ describe('releng version', () => {
 
         await setVersion(makeOptions('2.9.0', [pkgA, root]));
 
-        expect(readPackageJson('.').version).to.equal('2.9.0');
-        expect(readPackageJson('packages/a').version).to.equal('2.9.0');
+        expect(readPackageJson('.').version).toBe('2.9.0');
+        expect(readPackageJson('packages/a').version).toBe('2.9.0');
     });
 
     it('should preserve workspace: dependency ranges', async () => {
@@ -79,8 +79,8 @@ describe('releng version', () => {
 
         await setVersion(makeOptions('2.9.0', [pkgA, pkgB, root]));
 
-        expect(readPackageJson('packages/b').dependencies!['@eclipse-glsp/a']).to.equal('workspace:*');
-        expect(readPackageJson('packages/b').version).to.equal('2.9.0');
+        expect(readPackageJson('packages/b').dependencies!['@eclipse-glsp/a']).toBe('workspace:*');
+        expect(readPackageJson('packages/b').version).toBe('2.9.0');
     });
 
     it('should bump exact-pinned workspace dependencies to the new version', async () => {
@@ -93,7 +93,7 @@ describe('releng version', () => {
 
         await setVersion(makeOptions('2.9.0-next', [pkgA, pkgB, root]));
 
-        expect(readPackageJson('packages/b').dependencies!['@eclipse-glsp/a']).to.equal('2.9.0-next');
+        expect(readPackageJson('packages/b').dependencies!['@eclipse-glsp/a']).toBe('2.9.0-next');
     });
 
     it("should set external @eclipse-glsp dependencies to 'next' for next versions", async () => {
@@ -105,7 +105,7 @@ describe('releng version', () => {
 
         await setVersion(makeOptions('2.9.0-next', [pkgA, root]));
 
-        expect(readPackageJson('packages/a').dependencies!['@eclipse-glsp/protocol']).to.equal('next');
+        expect(readPackageJson('packages/a').dependencies!['@eclipse-glsp/protocol']).toBe('next');
     });
 
     it('should bump external @eclipse-glsp dependencies to the release version for release versions', async () => {
@@ -117,6 +117,6 @@ describe('releng version', () => {
 
         await setVersion(makeOptions('2.9.0', [pkgA, root]));
 
-        expect(readPackageJson('packages/a').dependencies!['@eclipse-glsp/protocol']).to.equal('2.9.0');
+        expect(readPackageJson('packages/a').dependencies!['@eclipse-glsp/protocol']).toBe('2.9.0');
     });
 });

--- a/dev-packages/cli/src/commands/repo/build.spec.ts
+++ b/dev-packages/cli/src/commands/repo/build.spec.ts
@@ -56,43 +56,43 @@ describe('build-action', () => {
             createRepoDirs('glsp-client');
             await buildSingleRepo('glsp-client', makeOptions());
             expect(execAsyncStub).toHaveBeenCalledTimes(2);
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm install');
-            expect(execAsyncStub.mock.calls[1][0]).to.equal('pnpm run --if-present build');
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm install');
+            expect(execAsyncStub.mock.calls[1][0]).toBe('pnpm run --if-present build');
         });
 
         it('should run pnpm install, build and browser build for theia-integration', async () => {
             createRepoDirs('glsp-theia-integration');
             await buildSingleRepo('glsp-theia-integration', makeOptions());
             expect(execAsyncStub).toHaveBeenCalledTimes(3);
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm install');
-            expect(execAsyncStub.mock.calls[1][0]).to.equal('pnpm run --if-present build');
-            expect(execAsyncStub.mock.calls[2][0]).to.equal('pnpm run browser build');
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm install');
+            expect(execAsyncStub.mock.calls[1][0]).toBe('pnpm run --if-present build');
+            expect(execAsyncStub.mock.calls[2][0]).toBe('pnpm run browser build');
         });
 
         it('should run electron build with --electron', async () => {
             createRepoDirs('glsp-theia-integration');
             await buildSingleRepo('glsp-theia-integration', makeOptions({ electron: true }));
             expect(execAsyncStub).toHaveBeenCalledTimes(3);
-            expect(execAsyncStub.mock.calls[2][0]).to.equal('pnpm run electron build');
+            expect(execAsyncStub.mock.calls[2][0]).toBe('pnpm run electron build');
         });
 
         it('should run mvn for glsp-server', async () => {
             createRepoDirs('glsp-server');
             await buildSingleRepo('glsp-server', makeOptions());
             expect(execAsyncStub).toHaveBeenCalledOnce();
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B');
+            expect(execAsyncStub.mock.calls[0][0]).toBe('mvn clean verify -Pm2 -Pfatjar -Dstyle.color=always -B');
         });
 
         it('should build client and server for eclipse-integration', async () => {
             createRepoDirs(path.join('glsp-eclipse-integration', 'client'));
             await buildSingleRepo('glsp-eclipse-integration', makeOptions());
             expect(execAsyncStub).toHaveBeenCalledTimes(3);
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm install');
-            expect(execAsyncStub.mock.calls[0][1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
-            expect(execAsyncStub.mock.calls[1][0]).to.equal('pnpm run --if-present build');
-            expect(execAsyncStub.mock.calls[1][1].cwd).to.contain(path.join('glsp-eclipse-integration', 'client'));
-            expect(execAsyncStub.mock.calls[2][0]).to.equal('mvn clean verify -Dstyle.color=always -B');
-            expect(execAsyncStub.mock.calls[2][1].cwd).to.contain(path.join('glsp-eclipse-integration', 'server'));
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm install');
+            expect(execAsyncStub.mock.calls[0][1].cwd).toContain(path.join('glsp-eclipse-integration', 'client'));
+            expect(execAsyncStub.mock.calls[1][0]).toBe('pnpm run --if-present build');
+            expect(execAsyncStub.mock.calls[1][1].cwd).toContain(path.join('glsp-eclipse-integration', 'client'));
+            expect(execAsyncStub.mock.calls[2][0]).toBe('mvn clean verify -Dstyle.color=always -B');
+            expect(execAsyncStub.mock.calls[2][1].cwd).toContain(path.join('glsp-eclipse-integration', 'server'));
         });
     });
 
@@ -100,7 +100,7 @@ describe('build-action', () => {
         it('should build repos sequentially in dependency order', async () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions());
-            expect(failures).to.equal(0);
+            expect(failures).toBe(0);
             // pnpm install + build per repo
             expect(execAsyncStub).toHaveBeenCalledTimes(6);
         });
@@ -111,7 +111,7 @@ describe('build-action', () => {
                 await runBuildOrdered(['glsp', 'glsp-client'], makeOptions());
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain('glsp-client');
+                expect((error as Error).message).toContain('glsp-client');
             }
         });
 
@@ -119,7 +119,7 @@ describe('build-action', () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
             execAsyncStub.mockRejectedValueOnce(new Error('build failed'));
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: true }));
-            expect(failures).to.equal(1);
+            expect(failures).toBe(1);
             expect(execAsyncStub).toHaveBeenCalledTimes(1);
         });
 
@@ -127,7 +127,7 @@ describe('build-action', () => {
             createRepoDirs('glsp', 'glsp-client', 'glsp-server-node');
             execAsyncStub.mockRejectedValueOnce(new Error('build failed'));
             const failures = await runBuildOrdered(['glsp', 'glsp-client', 'glsp-server-node'], makeOptions({ failFast: false }));
-            expect(failures).to.equal(1);
+            expect(failures).toBe(1);
             // first repo fails on install (1 call); the other two each run install + build (2+2)
             expect(execAsyncStub).toHaveBeenCalledTimes(5);
         });

--- a/dev-packages/cli/src/commands/repo/clone.spec.ts
+++ b/dev-packages/cli/src/commands/repo/clone.spec.ts
@@ -51,35 +51,35 @@ describe('clone-action', () => {
             await cloneSingleRepo('glsp-client', makeOptions());
             expect(execStub).toHaveBeenCalledOnce();
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('git clone');
-            expect(cmd).to.contain('https://github.com/eclipse-glsp/glsp-client.git');
-            expect(cmd).to.contain(path.join(tempDir, 'glsp-client'));
+            expect(cmd).toContain('git clone');
+            expect(cmd).toContain('https://github.com/eclipse-glsp/glsp-client.git');
+            expect(cmd).toContain(path.join(tempDir, 'glsp-client'));
         });
 
         it('should call git clone with ssh URL', async () => {
             await cloneSingleRepo('glsp-client', makeOptions({ protocol: 'ssh' }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('git@github.com:eclipse-glsp/glsp-client.git');
+            expect(cmd).toContain('git@github.com:eclipse-glsp/glsp-client.git');
         });
 
         it('should use fork org when --fork is set', async () => {
             await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('myuser/glsp-client');
+            expect(cmd).toContain('myuser/glsp-client');
         });
 
         it('should add upstream remote when --fork is set', async () => {
             await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
             const upstreamCall = execStub.mock.calls.find(c => (c[0] as string).includes('remote add upstream'));
-            expect(upstreamCall).to.exist;
-            expect(upstreamCall![0]).to.contain('eclipse-glsp/glsp-client');
+            expect(upstreamCall).toBeDefined();
+            expect(upstreamCall![0]).toContain('eclipse-glsp/glsp-client');
         });
 
         it('should not add upstream if already present after clone', async () => {
             vi.spyOn(forkUtils, 'getRemotes').mockReturnValue({ upstream: 'https://github.com/eclipse-glsp/glsp-client.git' });
             await cloneSingleRepo('glsp-client', makeOptions({ fork: 'myuser' }));
             const upstreamCall = execStub.mock.calls.find(c => (c[0] as string).includes('remote add upstream'));
-            expect(upstreamCall).to.be.undefined;
+            expect(upstreamCall).toBeUndefined();
         });
 
         it('should call ensureFork when --fork is set', async () => {
@@ -95,13 +95,13 @@ describe('clone-action', () => {
         it('should include -b flag when --branch is set', async () => {
             await cloneSingleRepo('glsp-client', makeOptions({ branch: 'release/2.0' }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('-b release/2.0');
+            expect(cmd).toContain('-b release/2.0');
         });
 
         it('should skip when target directory exists and no --override', async () => {
             fs.mkdirSync(path.join(tempDir, 'glsp-client'));
             const result = await cloneSingleRepo('glsp-client', makeOptions());
-            expect(result).to.be.false;
+            expect(result).toBe(false);
             expect(execStub).not.toHaveBeenCalled();
         });
 
@@ -110,7 +110,7 @@ describe('clone-action', () => {
             fs.mkdirSync(targetDir);
             fs.writeFileSync(path.join(targetDir, 'old.txt'), 'old');
             await cloneSingleRepo('glsp-client', makeOptions({ override: 'remove' }));
-            expect(fs.existsSync(path.join(targetDir, 'old.txt'))).to.be.false;
+            expect(fs.existsSync(path.join(targetDir, 'old.txt'))).toBe(false);
             expect(execStub).toHaveBeenCalledOnce();
         });
 
@@ -120,15 +120,15 @@ describe('clone-action', () => {
             fs.writeFileSync(path.join(targetDir, 'marker.txt'), 'original');
             await cloneSingleRepo('glsp-client', makeOptions({ override: 'rename' }));
             const entries = fs.readdirSync(tempDir).filter(e => e.startsWith('glsp-client_'));
-            expect(entries).to.have.lengthOf(1);
-            expect(fs.readFileSync(path.join(tempDir, entries[0], 'marker.txt'), 'utf-8')).to.equal('original');
+            expect(entries).toHaveLength(1);
+            expect(fs.readFileSync(path.join(tempDir, entries[0], 'marker.txt'), 'utf-8')).toBe('original');
         });
 
         it('should use gh repo clone for gh protocol', async () => {
             await cloneSingleRepo('glsp-client', makeOptions({ protocol: 'gh' }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('gh repo clone');
-            expect(cmd).to.contain('eclipse-glsp/glsp-client');
+            expect(cmd).toContain('gh repo clone');
+            expect(cmd).toContain('eclipse-glsp/glsp-client');
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/common/utils.spec.ts
+++ b/dev-packages/cli/src/commands/repo/common/utils.spec.ts
@@ -42,20 +42,20 @@ describe('workspace-resolution', () => {
             const dir = path.join(tempDir, 'my-workspace');
             fs.mkdirSync(dir, { recursive: true });
             const result = resolveWorkspaceDir(dir);
-            expect(result).to.equal(dir);
+            expect(result).toBe(dir);
         });
 
         it('should resolve a relative cliDir against cwd', () => {
             process.chdir(tempDir);
             fs.mkdirSync(path.join(tempDir, 'sub'), { recursive: true });
             const result = resolveWorkspaceDir('sub');
-            expect(result).to.equal(path.resolve(tempDir, 'sub'));
+            expect(result).toBe(path.resolve(tempDir, 'sub'));
         });
 
         it('should return cwd when no cliDir and not inside a known repo', () => {
             process.chdir(tempDir);
             const result = resolveWorkspaceDir();
-            expect(result).to.equal(tempDir);
+            expect(result).toBe(tempDir);
         });
 
         it('should return the parent of a known repo root when inside one', () => {
@@ -63,7 +63,7 @@ describe('workspace-resolution', () => {
             fs.mkdirSync(repoDir, { recursive: true });
             process.chdir(repoDir);
             const result = resolveWorkspaceDir();
-            expect(result).to.equal(tempDir);
+            expect(result).toBe(tempDir);
         });
 
         it('should walk up from a nested directory inside a known repo', () => {
@@ -72,7 +72,7 @@ describe('workspace-resolution', () => {
             fs.mkdirSync(nestedDir, { recursive: true });
             process.chdir(nestedDir);
             const result = resolveWorkspaceDir();
-            expect(result).to.equal(tempDir);
+            expect(result).toBe(tempDir);
         });
     });
 });
@@ -95,7 +95,7 @@ describe('repo-discovery', () => {
             fs.mkdirSync(path.join(tempDir, 'glsp-client'));
             fs.mkdirSync(path.join(tempDir, 'glsp-server-node'));
             const repos = discoverRepos(tempDir);
-            expect(repos).to.deep.equal(['glsp-server-node', 'glsp-client']);
+            expect(repos).toEqual(['glsp-server-node', 'glsp-client']);
         });
 
         it('should ignore non-GLSP directories', () => {
@@ -103,19 +103,19 @@ describe('repo-discovery', () => {
             fs.mkdirSync(path.join(tempDir, 'my-project'));
             fs.mkdirSync(path.join(tempDir, 'node_modules'));
             const repos = discoverRepos(tempDir);
-            expect(repos).to.deep.equal(['glsp-client']);
+            expect(repos).toEqual(['glsp-client']);
         });
 
         it('should ignore files matching GLSP repo names', () => {
             fs.mkdirSync(path.join(tempDir, 'glsp-client'));
             fs.writeFileSync(path.join(tempDir, 'glsp-server-node'), 'not a dir');
             const repos = discoverRepos(tempDir);
-            expect(repos).to.deep.equal(['glsp-client']);
+            expect(repos).toEqual(['glsp-client']);
         });
 
         it('should return empty array for nonexistent directory', () => {
             const repos = discoverRepos(path.join(tempDir, 'nonexistent'));
-            expect(repos).to.deep.equal([]);
+            expect(repos).toEqual([]);
         });
 
         it('should return repos sorted by GLSPRepo.choices order', () => {
@@ -123,13 +123,13 @@ describe('repo-discovery', () => {
             fs.mkdirSync(path.join(tempDir, 'glsp'));
             fs.mkdirSync(path.join(tempDir, 'glsp-client'));
             const repos = discoverRepos(tempDir);
-            expect(repos).to.deep.equal(['glsp', 'glsp-client', 'glsp-theia-integration']);
+            expect(repos).toEqual(['glsp', 'glsp-client', 'glsp-theia-integration']);
         });
 
         it('should return empty array when no GLSP repos exist', () => {
             fs.mkdirSync(path.join(tempDir, 'some-project'));
             const repos = discoverRepos(tempDir);
-            expect(repos).to.deep.equal([]);
+            expect(repos).toEqual([]);
         });
     });
 });
@@ -144,22 +144,22 @@ describe('repo-graph', () => {
             const glspIdx = order.indexOf('glsp');
             const clientIdx = order.indexOf('glsp-client');
             const serverNodeIdx = order.indexOf('glsp-server-node');
-            expect(glspIdx).to.be.lessThan(clientIdx);
-            expect(clientIdx).to.be.lessThan(serverNodeIdx);
+            expect(glspIdx).toBeLessThan(clientIdx);
+            expect(clientIdx).toBeLessThan(serverNodeIdx);
         });
 
         it('should include only requested repos', () => {
             const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
             const order = getBuildOrder(repos);
-            expect(order).to.have.lengthOf(2);
-            expect(order).to.include('glsp-client');
-            expect(order).to.include('glsp-server-node');
+            expect(order).toHaveLength(2);
+            expect(order).toContain('glsp-client');
+            expect(order).toContain('glsp-server-node');
         });
 
         it('should handle independent repos', () => {
             const repos: GLSPRepo[] = ['glsp-playwright'];
             const order = getBuildOrder(repos);
-            expect(order).to.deep.equal(['glsp-playwright']);
+            expect(order).toEqual(['glsp-playwright']);
         });
 
         it('should place glsp-server before glsp-eclipse-integration', () => {
@@ -167,22 +167,22 @@ describe('repo-graph', () => {
             const order = getBuildOrder(repos);
             const serverIdx = order.indexOf('glsp-server');
             const eclipseIdx = order.indexOf('glsp-eclipse-integration');
-            expect(serverIdx).to.be.lessThan(eclipseIdx);
+            expect(serverIdx).toBeLessThan(eclipseIdx);
         });
     });
 
     describe('isLeafRepo', () => {
         it('should return true for repos that no other repo depends on', () => {
-            expect(isLeafRepo('glsp-theia-integration')).to.be.true;
-            expect(isLeafRepo('glsp-vscode-integration')).to.be.true;
-            expect(isLeafRepo('glsp-playwright')).to.be.true;
+            expect(isLeafRepo('glsp-theia-integration')).toBe(true);
+            expect(isLeafRepo('glsp-vscode-integration')).toBe(true);
+            expect(isLeafRepo('glsp-playwright')).toBe(true);
         });
 
         it('should return false for repos that are dependencies of other repos', () => {
-            expect(isLeafRepo('glsp')).to.be.false;
-            expect(isLeafRepo('glsp-client')).to.be.false;
-            expect(isLeafRepo('glsp-server-node')).to.be.false;
-            expect(isLeafRepo('glsp-server')).to.be.false;
+            expect(isLeafRepo('glsp')).toBe(false);
+            expect(isLeafRepo('glsp-client')).toBe(false);
+            expect(isLeafRepo('glsp-server-node')).toBe(false);
+            expect(isLeafRepo('glsp-server')).toBe(false);
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/fork.spec.ts
+++ b/dev-packages/cli/src/commands/repo/fork.spec.ts
@@ -26,33 +26,33 @@ import { configureForkRemote } from './fork';
 describe('fork-utils', () => {
     describe('getRemoteUrl', () => {
         it('should return SSH URL for ssh protocol', () => {
-            expect(getRemoteUrl('ssh', 'myuser', 'glsp-client')).to.equal('git@github.com:myuser/glsp-client.git');
+            expect(getRemoteUrl('ssh', 'myuser', 'glsp-client')).toBe('git@github.com:myuser/glsp-client.git');
         });
 
         it('should return HTTPS URL for https protocol', () => {
-            expect(getRemoteUrl('https', 'myuser', 'glsp-client')).to.equal('https://github.com/myuser/glsp-client.git');
+            expect(getRemoteUrl('https', 'myuser', 'glsp-client')).toBe('https://github.com/myuser/glsp-client.git');
         });
 
         it('should return HTTPS URL for gh protocol', () => {
-            expect(getRemoteUrl('gh', 'myuser', 'glsp-client')).to.equal('https://github.com/myuser/glsp-client.git');
+            expect(getRemoteUrl('gh', 'myuser', 'glsp-client')).toBe('https://github.com/myuser/glsp-client.git');
         });
     });
 
     describe('remoteMatchesOrg', () => {
         it('should match HTTPS URL', () => {
-            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.true;
+            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).toBe(true);
         });
 
         it('should match SSH URL', () => {
-            expect(remoteMatchesOrg('git@github.com:eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.true;
+            expect(remoteMatchesOrg('git@github.com:eclipse-glsp/glsp-client.git', 'eclipse-glsp', 'glsp-client')).toBe(true);
         });
 
         it('should not match different org', () => {
-            expect(remoteMatchesOrg('https://github.com/myuser/glsp-client.git', 'eclipse-glsp', 'glsp-client')).to.be.false;
+            expect(remoteMatchesOrg('https://github.com/myuser/glsp-client.git', 'eclipse-glsp', 'glsp-client')).toBe(false);
         });
 
         it('should not match different repo', () => {
-            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-server-node.git', 'eclipse-glsp', 'glsp-client')).to.be.false;
+            expect(remoteMatchesOrg('https://github.com/eclipse-glsp/glsp-server-node.git', 'eclipse-glsp', 'glsp-client')).toBe(false);
         });
     });
 
@@ -65,14 +65,14 @@ describe('fork-utils', () => {
                 origin: 'git@github.com:myuser/glsp-client.git',
                 upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('already-configured');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('already-configured');
         });
 
         it('should return rename-origin when origin=eclipse-glsp and no upstream', () => {
             const remotes: RemoteInfo = {
                 origin: 'https://github.com/eclipse-glsp/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('rename-origin');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('rename-origin');
         });
 
         it('should return set-origin when origin=eclipse-glsp and upstream=eclipse-glsp', () => {
@@ -80,7 +80,7 @@ describe('fork-utils', () => {
                 origin: 'https://github.com/eclipse-glsp/glsp-client.git',
                 upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('set-origin');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('set-origin');
         });
 
         it('should return unexpected when origin=eclipse-glsp and upstream=something-else', () => {
@@ -88,33 +88,33 @@ describe('fork-utils', () => {
                 origin: 'https://github.com/eclipse-glsp/glsp-client.git',
                 upstream: 'https://github.com/other-org/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('unexpected');
         });
 
         it('should return unexpected when origin is unknown org', () => {
             const remotes: RemoteInfo = {
                 origin: 'https://github.com/other-org/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('unexpected');
         });
 
         it('should return unexpected when no remotes exist', () => {
             const remotes: RemoteInfo = {};
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('unexpected');
         });
 
         it('should return unexpected when only upstream exists', () => {
             const remotes: RemoteInfo = {
                 upstream: 'https://github.com/eclipse-glsp/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('unexpected');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('unexpected');
         });
 
         it('should handle SSH URLs for eclipse-glsp origin', () => {
             const remotes: RemoteInfo = {
                 origin: 'git@github.com:eclipse-glsp/glsp-client.git'
             };
-            expect(analyzeForkRemotes(remotes, forkUser, repo)).to.equal('rename-origin');
+            expect(analyzeForkRemotes(remotes, forkUser, repo)).toBe('rename-origin');
         });
     });
 });
@@ -152,10 +152,10 @@ describe('fork-action', () => {
 
             expect(ensureForkStub).toHaveBeenCalledExactlyOnceWith('myuser', 'glsp-client');
             const calls = execStub.mock.calls.map(c => c[0] as string);
-            expect(calls).to.include('git remote rename origin upstream');
+            expect(calls).toContain('git remote rename origin upstream');
             const addOrigin = calls.find(c => c.includes('git remote add origin'));
-            expect(addOrigin).to.exist;
-            expect(addOrigin).to.contain('git@github.com:myuser/glsp-client.git');
+            expect(addOrigin).toBeDefined();
+            expect(addOrigin).toContain('git@github.com:myuser/glsp-client.git');
         });
 
         it('should set origin URL for set-origin flow', async () => {
@@ -170,8 +170,8 @@ describe('fork-action', () => {
             expect(ensureForkStub).toHaveBeenCalledExactlyOnceWith('myuser', 'glsp-client');
             const calls = execStub.mock.calls.map(c => c[0] as string);
             const setUrl = calls.find(c => c.includes('git remote set-url origin'));
-            expect(setUrl).to.exist;
-            expect(setUrl).to.contain('https://github.com/myuser/glsp-client.git');
+            expect(setUrl).toBeDefined();
+            expect(setUrl).toContain('https://github.com/myuser/glsp-client.git');
         });
 
         it('should skip when already configured', async () => {
@@ -204,7 +204,7 @@ describe('fork-action', () => {
             await configureForkRemote('glsp-client', repoDir, 'myuser', 'ssh');
 
             const addOriginCall = execStub.mock.calls.find(c => (c[0] as string).includes('git remote add origin'));
-            expect(addOriginCall![0]).to.contain('git@github.com:myuser/glsp-client.git');
+            expect(addOriginCall![0]).toContain('git@github.com:myuser/glsp-client.git');
         });
 
         it('should use https URL when protocol is https', async () => {
@@ -214,7 +214,7 @@ describe('fork-action', () => {
             await configureForkRemote('glsp-client', repoDir, 'myuser', 'https');
 
             const addOriginCall = execStub.mock.calls.find(c => (c[0] as string).includes('git remote add origin'));
-            expect(addOriginCall![0]).to.contain('https://github.com/myuser/glsp-client.git');
+            expect(addOriginCall![0]).toContain('https://github.com/myuser/glsp-client.git');
         });
 
         it('should pass correct cwd for git commands', async () => {
@@ -224,7 +224,7 @@ describe('fork-action', () => {
             await configureForkRemote('glsp-server-node', repoDir, 'myuser', 'ssh');
 
             for (const call of execStub.mock.calls) {
-                expect(call[1]).to.have.property('cwd', repoDir);
+                expect(call[1]).toHaveProperty('cwd', repoDir);
             }
         });
 

--- a/dev-packages/cli/src/commands/repo/link.spec.ts
+++ b/dev-packages/cli/src/commands/repo/link.spec.ts
@@ -115,17 +115,17 @@ describe('link-action', () => {
     describe('filterLinkableRepos', () => {
         it('should keep linkable npm repos', () => {
             const result = filterLinkableRepos(['glsp-client', 'glsp-server-node', 'glsp-theia-integration'] as GLSPRepo[]);
-            expect(result).to.deep.equal(['glsp-client', 'glsp-server-node', 'glsp-theia-integration']);
+            expect(result).toEqual(['glsp-client', 'glsp-server-node', 'glsp-theia-integration']);
         });
 
         it('should keep glsp-eclipse-integration', () => {
             const result = filterLinkableRepos(['glsp-client', 'glsp-eclipse-integration'] as GLSPRepo[]);
-            expect(result).to.deep.equal(['glsp-client', 'glsp-eclipse-integration']);
+            expect(result).toEqual(['glsp-client', 'glsp-eclipse-integration']);
         });
 
         it('should exclude non-linkable repos', () => {
             const result = filterLinkableRepos(['glsp-client', 'glsp-server', 'glsp-playwright'] as GLSPRepo[]);
-            expect(result).to.deep.equal(['glsp-client']);
+            expect(result).toEqual(['glsp-client']);
         });
     });
 
@@ -143,8 +143,8 @@ describe('link-action', () => {
                 return [];
             });
             const result = getGLSPWorkspacePackages(repoDir);
-            expect(result).to.have.length(2);
-            expect(result.map(p => p.name)).to.deep.equal(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
+            expect(result).toHaveLength(2);
+            expect(result.map(p => p.name)).toEqual(['@eclipse-glsp/client', '@eclipse-glsp/protocol']);
         });
     });
 
@@ -160,7 +160,7 @@ describe('link-action', () => {
                 }
                 return [];
             });
-            expect(collectProvidedPackages(repoDir)).to.deep.equal({
+            expect(collectProvidedPackages(repoDir)).toEqual({
                 '@eclipse-glsp/client': path.join(repoDir, 'packages/client'),
                 '@eclipse-glsp/protocol': path.join(repoDir, 'packages/protocol')
             });
@@ -172,7 +172,7 @@ describe('link-action', () => {
             createNodeModules('glsp-client', 'sprotty');
             const clientDir = path.join(tempDir, 'glsp-client');
             const dir = resolveSingletonDir([clientDir], 'sprotty');
-            expect(dir).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
+            expect(dir).toBe(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
         });
 
         it('should walk up to the package root when the entry has a nested manifest', () => {
@@ -186,13 +186,13 @@ describe('link-action', () => {
             fs.writeFileSync(path.join(invDir, 'lib', 'cjs', 'package.json'), JSON.stringify({ type: 'commonjs' }));
             fs.writeFileSync(path.join(invDir, 'lib', 'cjs', 'index.js'), 'module.exports = {};');
 
-            expect(resolveSingletonDir([clientDir], 'inversify')).to.equal(fs.realpathSync(invDir));
+            expect(resolveSingletonDir([clientDir], 'inversify')).toBe(fs.realpathSync(invDir));
         });
 
         it('should return undefined when the dependency is not resolvable from any dir', () => {
             createRepoDirs('glsp-client');
             fs.writeFileSync(path.join(tempDir, 'glsp-client', 'package.json'), JSON.stringify({ name: 'glsp-client' }));
-            expect(resolveSingletonDir([path.join(tempDir, 'glsp-client')], 'sprotty')).to.be.undefined;
+            expect(resolveSingletonDir([path.join(tempDir, 'glsp-client')], 'sprotty')).toBeUndefined();
         });
     });
 
@@ -202,10 +202,10 @@ describe('link-action', () => {
             createNodeModules('glsp-client', 'sprotty', 'inversify');
             const clientDir = path.join(tempDir, 'glsp-client');
             const links = collectSingletonLinks(clientDir);
-            expect(links.sprotty).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
-            expect(links.inversify).to.equal(fs.realpathSync(path.join(clientDir, 'node_modules', 'inversify')));
+            expect(links.sprotty).toBe(fs.realpathSync(path.join(clientDir, 'node_modules', 'sprotty')));
+            expect(links.inversify).toBe(fs.realpathSync(path.join(clientDir, 'node_modules', 'inversify')));
             // unresolvable singletons (sprotty-protocol, etc.) are simply skipped
-            expect(links['sprotty-protocol']).to.be.undefined;
+            expect(links['sprotty-protocol']).toBeUndefined();
         });
     });
 
@@ -217,8 +217,8 @@ describe('link-action', () => {
             applyLinkOverrides(repoDir, { '@eclipse-glsp/protocol': path.join(tempDir, 'glsp-client/packages/protocol') });
 
             const workspace = readWorkspaceYaml('glsp-server-node');
-            expect(workspace.packages).to.deep.equal(['packages/*']);
-            expect(workspace.overrides).to.deep.equal({
+            expect(workspace.packages).toEqual(['packages/*']);
+            expect(workspace.overrides).toEqual({
                 foo: '1.0.0',
                 '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol'
             });
@@ -228,14 +228,14 @@ describe('link-action', () => {
             createRepoDirs('glsp-server-node');
             const repoDir = path.join(tempDir, 'glsp-server-node');
             applyLinkOverrides(repoDir, { sprotty: path.join(tempDir, 'glsp-client/node_modules/sprotty') });
-            expect(readWorkspaceYaml('glsp-server-node').overrides).to.deep.equal({ sprotty: 'link:../glsp-client/node_modules/sprotty' });
+            expect(readWorkspaceYaml('glsp-server-node').overrides).toEqual({ sprotty: 'link:../glsp-client/node_modules/sprotty' });
         });
 
         it('should be a no-op for empty links', () => {
             createRepoDirs('glsp-server-node');
             const repoDir = path.join(tempDir, 'glsp-server-node');
             applyLinkOverrides(repoDir, {});
-            expect(fs.existsSync(path.join(repoDir, 'pnpm-workspace.yaml'))).to.be.false;
+            expect(fs.existsSync(path.join(repoDir, 'pnpm-workspace.yaml'))).toBe(false);
         });
     });
 
@@ -252,10 +252,10 @@ describe('link-action', () => {
                 }
             });
             const removed = removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
-            expect(removed).to.be.true;
+            expect(removed).toBe(true);
             const workspace = readWorkspaceYaml('glsp-server-node');
-            expect(workspace.packages).to.deep.equal(['packages/*']);
-            expect(workspace.overrides).to.deep.equal({ 'some-dep': '1.2.3' });
+            expect(workspace.packages).toEqual(['packages/*']);
+            expect(workspace.overrides).toEqual({ 'some-dep': '1.2.3' });
         });
 
         it('should drop the overrides key when it becomes empty', () => {
@@ -265,20 +265,20 @@ describe('link-action', () => {
                 overrides: { '@eclipse-glsp/protocol': 'link:../glsp-client/packages/protocol' }
             });
             removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
-            expect(readWorkspaceYaml('glsp-server-node')).to.not.have.property('overrides');
+            expect(readWorkspaceYaml('glsp-server-node')).not.toHaveProperty('overrides');
         });
 
         it('should not touch non-link overrides for the same package', () => {
             createRepoDirs('glsp-server-node');
             writeWorkspaceYaml('glsp-server-node', { overrides: { sprotty: '1.4.0' } });
             const removed = removeLinkOverrides(path.join(tempDir, 'glsp-server-node'));
-            expect(removed).to.be.false;
-            expect(readWorkspaceYaml('glsp-server-node').overrides).to.deep.equal({ sprotty: '1.4.0' });
+            expect(removed).toBe(false);
+            expect(readWorkspaceYaml('glsp-server-node').overrides).toEqual({ sprotty: '1.4.0' });
         });
 
         it('should return false when no workspace file exists', () => {
             createRepoDirs('glsp-server-node');
-            expect(removeLinkOverrides(path.join(tempDir, 'glsp-server-node'))).to.be.false;
+            expect(removeLinkOverrides(path.join(tempDir, 'glsp-server-node'))).toBe(false);
         });
     });
 
@@ -291,21 +291,21 @@ describe('link-action', () => {
             await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
 
             // glsp-client is the source of truth and gets no overrides.
-            expect(readWorkspaceYaml('glsp-client')).to.not.have.property('overrides');
+            expect(readWorkspaceYaml('glsp-client')).not.toHaveProperty('overrides');
 
             // glsp-server-node consumes glsp-client's packages and the shared singletons.
             const serverOverrides = readWorkspaceYaml('glsp-server-node').overrides ?? {};
-            expect(serverOverrides['@eclipse-glsp/client']).to.equal('link:../glsp-client/packages/client');
-            expect(serverOverrides['@eclipse-glsp/protocol']).to.equal('link:../glsp-client/packages/protocol');
+            expect(serverOverrides['@eclipse-glsp/client']).toBe('link:../glsp-client/packages/client');
+            expect(serverOverrides['@eclipse-glsp/protocol']).toBe('link:../glsp-client/packages/protocol');
             for (const dep of SINGLETON_DEPS) {
-                expect(serverOverrides[dep]).to.equal(`link:../glsp-client/node_modules/${dep}`);
+                expect(serverOverrides[dep]).toBe(`link:../glsp-client/node_modules/${dep}`);
             }
 
             // Each repo is installed (to apply the overrides) and then built, in build order:
             // install client, build client, install server-node, build server-node.
-            expect(execAsyncStub.mock.calls.length).to.equal(4);
+            expect(execAsyncStub.mock.calls.length).toBe(4);
             const calls = execAsyncStub.mock.calls.map(c => [c[0], c[1].cwd] as const);
-            expect(calls).to.deep.equal([
+            expect(calls).toEqual([
                 ['pnpm install --no-frozen-lockfile', path.join(tempDir, 'glsp-client')],
                 ['pnpm run --if-present build', path.join(tempDir, 'glsp-client')],
                 ['pnpm install --no-frozen-lockfile', path.join(tempDir, 'glsp-server-node')],
@@ -321,8 +321,8 @@ describe('link-action', () => {
             await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ build: false }));
 
             // Only the override-applying install runs per repo; no build.
-            expect(execAsyncStub.mock.calls.length).to.equal(2);
-            expect(execAsyncStub.mock.calls.every(c => c[0] === 'pnpm install --no-frozen-lockfile')).to.be.true;
+            expect(execAsyncStub.mock.calls.length).toBe(2);
+            expect(execAsyncStub.mock.calls.every(c => c[0] === 'pnpm install --no-frozen-lockfile')).toBe(true);
         });
 
         it('should link into the client/ subdir for glsp-eclipse-integration', async () => {
@@ -336,20 +336,20 @@ describe('link-action', () => {
             await runLink(['glsp-client', 'glsp-eclipse-integration'] as GLSPRepo[], makeOptions({ build: false }));
 
             // Overrides go into client/pnpm-workspace.yaml, not the repo root.
-            expect(fs.existsSync(path.join(tempDir, 'glsp-eclipse-integration', 'pnpm-workspace.yaml'))).to.be.false;
+            expect(fs.existsSync(path.join(tempDir, 'glsp-eclipse-integration', 'pnpm-workspace.yaml'))).toBe(false);
             const overrides = (YAML.parse(fs.readFileSync(path.join(clientDir, 'pnpm-workspace.yaml'), 'utf8')).overrides ?? {}) as Record<
                 string,
                 string
             >;
             // Relative link paths gain an extra ../ because the workspace is one level deeper than the repo root.
-            expect(overrides['@eclipse-glsp/client']).to.equal('link:../../glsp-client/packages/client');
+            expect(overrides['@eclipse-glsp/client']).toBe('link:../../glsp-client/packages/client');
             for (const dep of SINGLETON_DEPS) {
-                expect(overrides[dep]).to.equal(`link:../../glsp-client/node_modules/${dep}`);
+                expect(overrides[dep]).toBe(`link:../../glsp-client/node_modules/${dep}`);
             }
 
             // The install runs in the client/ workspace, not the repo root.
             const eclipseInstall = execAsyncStub.mock.calls.find(c => c[1].cwd === clientDir);
-            expect(eclipseInstall, 'install should run in client/').to.not.be.undefined;
+            expect(eclipseInstall, 'install should run in client/').toBeDefined();
         });
 
         it('should stop on first failure when failFast is true', async () => {
@@ -360,9 +360,9 @@ describe('link-action', () => {
                 await runLink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain('failed to link');
+                expect((error as Error).message).toContain('failed to link');
             }
-            expect(execAsyncStub.mock.calls.length).to.equal(1);
+            expect(execAsyncStub.mock.calls.length).toBe(1);
         });
 
         it('should skip non-linkable repos', async () => {
@@ -384,11 +384,11 @@ describe('link-action', () => {
 
             await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions());
 
-            expect(readWorkspaceYaml('glsp-server-node')).to.not.have.property('overrides');
+            expect(readWorkspaceYaml('glsp-server-node')).not.toHaveProperty('overrides');
             // Only glsp-server-node had overrides, so only it is reinstalled.
-            expect(execAsyncStub.mock.calls.length).to.equal(1);
-            expect(execAsyncStub.mock.calls[0][0]).to.equal('pnpm install --no-frozen-lockfile');
-            expect(execAsyncStub.mock.calls[0][1].cwd).to.equal(path.join(tempDir, 'glsp-server-node'));
+            expect(execAsyncStub.mock.calls.length).toBe(1);
+            expect(execAsyncStub.mock.calls[0][0]).toBe('pnpm install --no-frozen-lockfile');
+            expect(execAsyncStub.mock.calls[0][1].cwd).toBe(path.join(tempDir, 'glsp-server-node'));
         });
 
         it('should stop on first failure when failFast is true', async () => {
@@ -401,7 +401,7 @@ describe('link-action', () => {
                 await runUnlink(['glsp-client', 'glsp-server-node'] as GLSPRepo[], makeOptions({ failFast: true }));
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain('failed to unlink');
+                expect((error as Error).message).toContain('failed to unlink');
             }
         });
     });

--- a/dev-packages/cli/src/commands/repo/repo.spec.ts
+++ b/dev-packages/cli/src/commands/repo/repo.spec.ts
@@ -61,7 +61,7 @@ describe('repo --dir propagation', () => {
         parent.addCommand(createLeaf(captured));
 
         await parent.parseAsync(['node', 'test', '-d', '/test/path', 'leaf'], { from: 'node' });
-        expect(captured.dir).to.equal('/test/path');
+        expect(captured.dir).toBe('/test/path');
     });
 
     it('should not override subcommand --dir when explicitly set', async () => {
@@ -70,7 +70,7 @@ describe('repo --dir propagation', () => {
         parent.addCommand(createLeaf(captured));
 
         await parent.parseAsync(['node', 'test', '-d', '/parent', 'leaf', '-d', '/child'], { from: 'node' });
-        expect(captured.dir).to.equal('/child');
+        expect(captured.dir).toBe('/child');
     });
 
     it('should propagate --dir through middle layer to leaf', async () => {
@@ -81,7 +81,7 @@ describe('repo --dir propagation', () => {
         parent.addCommand(middle);
 
         await parent.parseAsync(['node', 'test', '-d', '/deep/path', 'middle', 'leaf'], { from: 'node' });
-        expect(captured.dir).to.equal('/deep/path');
+        expect(captured.dir).toBe('/deep/path');
     });
 
     it('should not propagate when parent --dir is not set', async () => {
@@ -90,7 +90,7 @@ describe('repo --dir propagation', () => {
         parent.addCommand(createLeaf(captured));
 
         await parent.parseAsync(['node', 'test', 'leaf'], { from: 'node' });
-        expect(captured.dir).to.be.undefined;
+        expect(captured.dir).toBeUndefined();
     });
 
     it('should allow leaf --dir to override through middle layer', async () => {
@@ -101,6 +101,6 @@ describe('repo --dir propagation', () => {
         parent.addCommand(middle);
 
         await parent.parseAsync(['node', 'test', '-d', '/parent', 'middle', 'leaf', '-d', '/leaf'], { from: 'node' });
-        expect(captured.dir).to.equal('/leaf');
+        expect(captured.dir).toBe('/leaf');
     });
 });

--- a/dev-packages/cli/src/commands/repo/run.spec.ts
+++ b/dev-packages/cli/src/commands/repo/run.spec.ts
@@ -21,29 +21,29 @@ describe('run-command', () => {
     describe('createScopedRunCommand', () => {
         it('should create a command named "run"', () => {
             const cmd = createScopedRunCommand('glsp-client');
-            expect(cmd.name()).to.equal('run');
+            expect(cmd.name()).toBe('run');
         });
 
         it('should include the repo name in the description', () => {
             const cmd = createScopedRunCommand('glsp-server-node');
-            expect(cmd.description()).to.contain('glsp-server-node');
+            expect(cmd.description()).toContain('glsp-server-node');
         });
 
         it('should require a script argument', () => {
             const cmd = createScopedRunCommand('glsp-client');
             const scriptArg = cmd.registeredArguments.find(a => a.name() === 'script');
-            expect(scriptArg).to.not.be.undefined;
-            expect(scriptArg!.required).to.be.true;
+            expect(scriptArg).toBeDefined();
+            expect(scriptArg!.required).toBe(true);
         });
 
         it('should allow unknown options for passthrough', () => {
             const cmd = createScopedRunCommand('glsp-client');
-            expect((cmd as any)._allowUnknownOption).to.be.true;
+            expect((cmd as any)._allowUnknownOption).toBe(true);
         });
 
         it('should allow excess arguments for passthrough', () => {
             const cmd = createScopedRunCommand('glsp-client');
-            expect((cmd as any)._allowExcessArguments).to.be.true;
+            expect((cmd as any)._allowExcessArguments).toBe(true);
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/server-node.spec.ts
+++ b/dev-packages/cli/src/commands/repo/server-node.spec.ts
@@ -42,27 +42,27 @@ describe('server-node', () => {
         it('should return absolute path when browser bundle exists', () => {
             createBundle(BROWSER_BUNDLE_PATH);
             const result = resolveBundlePath(tempDir, BROWSER_BUNDLE_PATH, 'Browser bundle');
-            expect(result).to.equal(path.resolve(tempDir, BROWSER_BUNDLE_PATH));
+            expect(result).toBe(path.resolve(tempDir, BROWSER_BUNDLE_PATH));
         });
 
         it('should return absolute path when node bundle exists', () => {
             createBundle(NODE_BUNDLE_PATH);
             const result = resolveBundlePath(tempDir, NODE_BUNDLE_PATH, 'Node server bundle');
-            expect(result).to.equal(path.resolve(tempDir, NODE_BUNDLE_PATH));
+            expect(result).toBe(path.resolve(tempDir, NODE_BUNDLE_PATH));
         });
 
         it('should throw when bundle does not exist', () => {
-            expect(() => resolveBundlePath(tempDir, BROWSER_BUNDLE_PATH, 'Browser bundle')).to.throw(/Browser bundle not found/);
+            expect(() => resolveBundlePath(tempDir, BROWSER_BUNDLE_PATH, 'Browser bundle')).toThrow(/Browser bundle not found/);
         });
 
         it('should include the expected path in the error message', () => {
-            expect(() => resolveBundlePath(tempDir, NODE_BUNDLE_PATH, 'Node server bundle')).to.throw(
+            expect(() => resolveBundlePath(tempDir, NODE_BUNDLE_PATH, 'Node server bundle')).toThrow(
                 new RegExp(NODE_BUNDLE_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
             );
         });
 
         it('should include build hint in the error message', () => {
-            expect(() => resolveBundlePath(tempDir, BROWSER_BUNDLE_PATH, 'Browser bundle')).to.throw(/glsp repo server-node build/);
+            expect(() => resolveBundlePath(tempDir, BROWSER_BUNDLE_PATH, 'Browser bundle')).toThrow(/glsp repo server-node build/);
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/start.spec.ts
+++ b/dev-packages/cli/src/commands/repo/start.spec.ts
@@ -61,7 +61,7 @@ describe('start-action', () => {
             const targetDir = createTargetDir();
             createJar(targetDir, 'org.eclipse.glsp.example.workflow-2.0.0-glsp.jar');
             const result = discoverJar(tempDir);
-            expect(result).to.contain('org.eclipse.glsp.example.workflow-2.0.0-glsp.jar');
+            expect(result).toContain('org.eclipse.glsp.example.workflow-2.0.0-glsp.jar');
         });
 
         it('should pick the newest JAR by mtime when multiple exist', () => {
@@ -69,38 +69,38 @@ describe('start-action', () => {
             createJar(targetDir, 'old-glsp.jar', 1000000);
             createJar(targetDir, 'new-glsp.jar', 2000000);
             const result = discoverJar(tempDir);
-            expect(result).to.contain('new-glsp.jar');
+            expect(result).toContain('new-glsp.jar');
         });
 
         it('should throw when no JAR is found', () => {
             createTargetDir();
-            expect(() => discoverJar(tempDir)).to.throw(/No \*-glsp\.jar found/);
+            expect(() => discoverJar(tempDir)).toThrow(/No \*-glsp\.jar found/);
         });
 
         it('should throw with helpful message when target directory does not exist', () => {
-            expect(() => discoverJar(tempDir)).to.throw(/glsp repo server build/);
+            expect(() => discoverJar(tempDir)).toThrow(/glsp repo server build/);
         });
     });
 
     describe('resolveCommand', () => {
         it('should resolve to a pnpm -C command', () => {
             const result = resolveCommand('start:websocket', tempDir, false);
-            expect(result).to.equal(`pnpm -C ${tempDir} start:websocket`);
+            expect(result).toBe(`pnpm -C ${tempDir} start:websocket`);
         });
 
         it('should return undefined on dry-run', () => {
             const result = resolveCommand('start:websocket', tempDir, true);
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
 
         it('should handle scripts with arguments', () => {
             const result = resolveCommand('start:websocket --port 8081', tempDir, false);
-            expect(result).to.equal(`pnpm -C ${tempDir} start:websocket --port 8081`);
+            expect(result).toBe(`pnpm -C ${tempDir} start:websocket --port 8081`);
         });
 
         it('should work even when the repo is not cloned yet', () => {
             const result = resolveCommand('start:websocket', '/not/cloned/repo', false);
-            expect(result).to.equal('pnpm -C /not/cloned/repo start:websocket');
+            expect(result).toBe('pnpm -C /not/cloned/repo start:websocket');
         });
     });
 
@@ -114,11 +114,11 @@ describe('start-action', () => {
 
         for (const { name, cmd } of commands) {
             it(`${name} should allow unknown options`, () => {
-                expect((cmd as any)._allowUnknownOption).to.be.true;
+                expect((cmd as any)._allowUnknownOption).toBe(true);
             });
 
             it(`${name} should allow excess arguments`, () => {
-                expect((cmd as any)._allowExcessArguments).to.be.true;
+                expect((cmd as any)._allowExcessArguments).toBe(true);
             });
         }
     });

--- a/dev-packages/cli/src/commands/repo/switch.spec.ts
+++ b/dev-packages/cli/src/commands/repo/switch.spec.ts
@@ -56,25 +56,25 @@ describe('switch-action', () => {
     describe('validateReposExist', () => {
         it('should pass when all repos exist', () => {
             createRepoDirs('glsp-client', 'glsp-server-node');
-            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).to.not.throw();
+            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).not.toThrow();
         });
 
         it('should throw listing missing repos', () => {
             createRepoDirs('glsp-client');
-            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).to.throw(/not cloned.*glsp-server-node/);
+            expect(() => validateReposExist(['glsp-client', 'glsp-server-node'], tempDir)).toThrow(/not cloned.*glsp-server-node/);
         });
     });
 
     describe('validateReposClean', () => {
         it('should pass when all repos are clean', () => {
             createRepoDirs('glsp-client');
-            expect(() => validateReposClean(['glsp-client'], tempDir)).to.not.throw();
+            expect(() => validateReposClean(['glsp-client'], tempDir)).not.toThrow();
         });
 
         it('should throw listing dirty repos', () => {
             createRepoDirs('glsp-client');
             vi.mocked(gitUtil.hasChanges).mockReturnValue(true);
-            expect(() => validateReposClean(['glsp-client'], tempDir)).to.throw(/uncommitted changes.*glsp-client/);
+            expect(() => validateReposClean(['glsp-client'], tempDir)).toThrow(/uncommitted changes.*glsp-client/);
         });
     });
 
@@ -84,15 +84,15 @@ describe('switch-action', () => {
             switchSingleRepo('glsp-client', makeOptions({ branch: 'release/2.0' }));
             expect(execStub).toHaveBeenCalledOnce();
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('git checkout');
-            expect(cmd).to.contain('release/2.0');
+            expect(cmd).toContain('git checkout');
+            expect(cmd).toContain('release/2.0');
         });
 
         it('should add --force when force is true', () => {
             createRepoDirs('glsp-client');
             switchSingleRepo('glsp-client', makeOptions({ branch: 'main', force: true }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('--force');
+            expect(cmd).toContain('--force');
         });
 
         it('should warn and return when branch does not exist', () => {
@@ -100,7 +100,7 @@ describe('switch-action', () => {
             execStub.mockImplementation(() => {
                 throw new Error("error: pathspec 'nonexistent' did not match any");
             });
-            expect(() => switchSingleRepo('glsp-client', makeOptions({ branch: 'nonexistent' }))).to.not.throw();
+            expect(() => switchSingleRepo('glsp-client', makeOptions({ branch: 'nonexistent' }))).not.toThrow();
         });
 
         it('should rethrow on other git errors', () => {
@@ -108,15 +108,15 @@ describe('switch-action', () => {
             execStub.mockImplementation(() => {
                 throw new Error('fatal: some other error');
             });
-            expect(() => switchSingleRepo('glsp-client', makeOptions())).to.throw('fatal: some other error');
+            expect(() => switchSingleRepo('glsp-client', makeOptions())).toThrow('fatal: some other error');
         });
 
         it('should use gh pr checkout for --pr', () => {
             createRepoDirs('glsp-client');
             switchSingleRepo('glsp-client', makeOptions({ branch: undefined, pr: '42' }));
             const cmd = execStub.mock.calls[0][0] as string;
-            expect(cmd).to.contain('gh pr checkout 42');
-            expect(cmd).to.contain('-R eclipse-glsp/glsp-client');
+            expect(cmd).toContain('gh pr checkout 42');
+            expect(cmd).toContain('-R eclipse-glsp/glsp-client');
         });
     });
 });

--- a/dev-packages/cli/src/commands/repo/workspace.spec.ts
+++ b/dev-packages/cli/src/commands/repo/workspace.spec.ts
@@ -48,9 +48,9 @@ describe('workspace-action', () => {
             const repos: GLSPRepo[] = ['glsp-client', 'glsp-server-node'];
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
-            expect(result.folders).to.have.length(2);
-            expect(result.folders[0]).to.deep.equal({ name: 'glsp-client', path: 'glsp-client' });
-            expect(result.folders[1]).to.deep.equal({ name: 'glsp-server-node', path: 'glsp-server-node' });
+            expect(result.folders).toHaveLength(2);
+            expect(result.folders[0]).toEqual({ name: 'glsp-client', path: 'glsp-client' });
+            expect(result.folders[1]).toEqual({ name: 'glsp-server-node', path: 'glsp-server-node' });
         });
 
         it('should compute paths relative to custom output location', () => {
@@ -59,23 +59,23 @@ describe('workspace-action', () => {
 
             const result = generateWorkspaceContent(repos, tempDir, makeOptions({ outputPath }));
 
-            expect(result.folders[0].path).to.equal(path.join('..', '..', 'glsp-client'));
+            expect(result.folders[0].path).toBe(path.join('..', '..', 'glsp-client'));
         });
 
         it('should include build, link, and unlink tasks', () => {
             const repos: GLSPRepo[] = ['glsp-client'];
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
-            expect(result.tasks.version).to.equal('2.0.0');
+            expect(result.tasks.version).toBe('2.0.0');
             const labels = result.tasks.tasks.map(t => t.label);
-            expect(labels).to.include('GLSP: Build all');
-            expect(labels).to.include('GLSP: Link');
-            expect(labels).to.include('GLSP: Unlink');
+            expect(labels).toContain('GLSP: Build all');
+            expect(labels).toContain('GLSP: Link');
+            expect(labels).toContain('GLSP: Unlink');
 
             const buildAll = result.tasks.tasks.find(t => t.label === 'GLSP: Build all')!;
-            expect(buildAll.type).to.equal('shell');
-            expect(buildAll.command).to.equal('npx @eclipse-glsp/cli repo build --no-java');
-            expect(buildAll.group).to.deep.equal({ kind: 'build', isDefault: true });
+            expect(buildAll.type).toBe('shell');
+            expect(buildAll.command).toBe('npx @eclipse-glsp/cli repo build --no-java');
+            expect(buildAll.group).toEqual({ kind: 'build', isDefault: true });
         });
 
         it('should include Java build task when Java repos are present', () => {
@@ -83,7 +83,7 @@ describe('workspace-action', () => {
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
             const labels = result.tasks.tasks.map(t => t.label);
-            expect(labels).to.include('GLSP: Build all (incl. Java)');
+            expect(labels).toContain('GLSP: Build all (incl. Java)');
         });
 
         it('should not include Java build task when no Java repos are present', () => {
@@ -91,7 +91,7 @@ describe('workspace-action', () => {
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
             const labels = result.tasks.tasks.map(t => t.label);
-            expect(labels).to.not.include('GLSP: Build all (incl. Java)');
+            expect(labels).not.toContain('GLSP: Build all (incl. Java)');
         });
 
         it('should include preset build tasks for matching strict subsets', () => {
@@ -99,14 +99,14 @@ describe('workspace-action', () => {
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
             const labels = result.tasks.tasks.map(t => t.label);
-            expect(labels).to.include('GLSP: Build core');
+            expect(labels).toContain('GLSP: Build core');
         });
 
         it('should include extension recommendations', () => {
             const repos: GLSPRepo[] = ['glsp-client'];
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
-            expect(result.extensions.recommendations).to.deep.equal([
+            expect(result.extensions.recommendations).toEqual([
                 'dbaeumer.vscode-eslint',
                 'esbenp.prettier-vscode',
                 'DavidAnson.vscode-markdownlint'
@@ -117,7 +117,7 @@ describe('workspace-action', () => {
             const repos: GLSPRepo[] = ['glsp-client'];
             const result = generateWorkspaceContent(repos, tempDir, makeOptions());
 
-            expect(result.settings).to.deep.equal({});
+            expect(result.settings).toEqual({});
         });
     });
 
@@ -126,11 +126,11 @@ describe('workspace-action', () => {
             const repos: GLSPRepo[] = ['glsp-client'];
             const outputFile = generateWorkspaceFile(repos, tempDir, makeOptions());
 
-            expect(outputFile).to.equal(path.join(tempDir, WORKSPACE_FILE_NAME));
-            expect(fs.existsSync(outputFile)).to.be.true;
+            expect(outputFile).toBe(path.join(tempDir, WORKSPACE_FILE_NAME));
+            expect(fs.existsSync(outputFile)).toBe(true);
 
             const content: VSCodeWorkspace = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
-            expect(content.folders).to.have.length(1);
+            expect(content.folders).toHaveLength(1);
         });
 
         it('should write to a custom output path', () => {
@@ -139,8 +139,8 @@ describe('workspace-action', () => {
 
             const outputFile = generateWorkspaceFile(repos, tempDir, makeOptions({ outputPath }));
 
-            expect(outputFile).to.equal(outputPath);
-            expect(fs.existsSync(outputFile)).to.be.true;
+            expect(outputFile).toBe(outputPath);
+            expect(fs.existsSync(outputFile)).toBe(true);
         });
 
         it('should overwrite an existing workspace file', () => {
@@ -152,7 +152,7 @@ describe('workspace-action', () => {
 
             const outputFile = path.join(tempDir, WORKSPACE_FILE_NAME);
             const content: VSCodeWorkspace = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
-            expect(content.folders).to.have.length(2);
+            expect(content.folders).toHaveLength(2);
         });
     });
 
@@ -160,24 +160,24 @@ describe('workspace-action', () => {
         it('should find a single .code-workspace file', () => {
             fs.writeFileSync(path.join(tempDir, 'glsp.code-workspace'), '{}');
             const result = discoverWorkspaceFile(tempDir);
-            expect(result).to.equal(path.join(tempDir, 'glsp.code-workspace'));
+            expect(result).toBe(path.join(tempDir, 'glsp.code-workspace'));
         });
 
         it('should return undefined when no .code-workspace file exists', () => {
             const result = discoverWorkspaceFile(tempDir);
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
 
         it('should prefer glsp.code-workspace when multiple exist', () => {
             fs.writeFileSync(path.join(tempDir, 'glsp.code-workspace'), '{}');
             fs.writeFileSync(path.join(tempDir, 'other.code-workspace'), '{}');
             const result = discoverWorkspaceFile(tempDir);
-            expect(result).to.equal(path.join(tempDir, 'glsp.code-workspace'));
+            expect(result).toBe(path.join(tempDir, 'glsp.code-workspace'));
         });
 
         it('should return undefined for nonexistent directory', () => {
             const result = discoverWorkspaceFile(path.join(tempDir, 'nonexistent'));
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
     });
 });

--- a/dev-packages/cli/src/commands/update-next.spec.ts
+++ b/dev-packages/cli/src/commands/update-next.spec.ts
@@ -81,14 +81,14 @@ describe('updateNext', () => {
         const yamlDuringInstall = await runAndCaptureWorkspaceYaml(workspaceYamlPath);
 
         // the resolved next version is pinned via the overrides block while installing ...
-        expect(YAML.parse(yamlDuringInstall).overrides).to.deep.equal({ '@eclipse-glsp/protocol': '2.8.0-next.6' });
+        expect(YAML.parse(yamlDuringInstall).overrides).toEqual({ '@eclipse-glsp/protocol': '2.8.0-next.6' });
         // ... and the file is restored verbatim afterwards
-        expect(fs.readFileSync(workspaceYamlPath, 'utf8')).to.equal(originalYaml);
+        expect(fs.readFileSync(workspaceYamlPath, 'utf8')).toBe(originalYaml);
 
         const commands = execAsyncStub.mock.calls.map(call => call[0] as string);
         // uses `pnpm install` (lockfile-respecting), never `pnpm update` (opportunistic in-range bumps)
-        expect(commands.some(cmd => cmd.includes('pnpm install'))).to.be.true;
-        expect(commands.some(cmd => cmd.includes('pnpm update'))).to.be.false;
+        expect(commands.some(cmd => cmd.includes('pnpm install'))).toBe(true);
+        expect(commands.some(cmd => cmd.includes('pnpm update'))).toBe(false);
     });
 
     it('should merge into an existing overrides block (ours win) and restore it afterwards', async () => {
@@ -111,12 +111,12 @@ describe('updateNext', () => {
         const yamlDuringInstall = await runAndCaptureWorkspaceYaml(workspaceYamlPath);
 
         // existing override preserved, our pin merged in / overriding the stale one
-        expect(YAML.parse(yamlDuringInstall).overrides).to.deep.equal({
+        expect(YAML.parse(yamlDuringInstall).overrides).toEqual({
             'unrelated-dep': '1.2.3',
             '@eclipse-glsp/protocol': '2.8.0-next.6'
         });
         // original file restored verbatim
-        expect(fs.readFileSync(workspaceYamlPath, 'utf8')).to.equal(originalYaml);
+        expect(fs.readFileSync(workspaceYamlPath, 'utf8')).toBe(originalYaml);
     });
 
     it('should do nothing when a pnpm repo has no next dependencies', async () => {

--- a/dev-packages/cli/src/util/file-util.spec.ts
+++ b/dev-packages/cli/src/util/file-util.spec.ts
@@ -38,19 +38,19 @@ describe('file-util', () => {
 
             const result = readFile(filePath, { startLine: 2, endLine: 3 });
 
-            expect(result).to.contain('line2');
-            expect(result).to.contain('line3');
-            expect(result).to.not.contain('line1');
-            expect(result).to.not.contain('line4');
+            expect(result).toContain('line2');
+            expect(result).toContain('line3');
+            expect(result).not.toContain('line1');
+            expect(result).not.toContain('line4');
         });
 
         it('should throw for a non-existent file', () => {
             const filePath = path.join(tempDir, 'missing.txt');
-            expect(() => readFile(filePath)).to.throw(/no such file/);
+            expect(() => readFile(filePath)).toThrow(/no such file/);
         });
 
         it('should throw for a directory path', () => {
-            expect(() => readFile(tempDir)).to.throw(/Is a directory/);
+            expect(() => readFile(tempDir)).toThrow(/Is a directory/);
         });
     });
 
@@ -61,7 +61,7 @@ describe('file-util', () => {
 
             deleteFile(filePath);
 
-            expect(fs.existsSync(filePath)).to.be.false;
+            expect(fs.existsSync(filePath)).toBe(false);
         });
 
         it('should delete a directory recursively', () => {
@@ -71,12 +71,12 @@ describe('file-util', () => {
 
             deleteFile(dirPath);
 
-            expect(fs.existsSync(dirPath)).to.be.false;
+            expect(fs.existsSync(dirPath)).toBe(false);
         });
 
         it('should throw for a non-existent path', () => {
             const filePath = path.join(tempDir, 'no-such-file.txt');
-            expect(() => deleteFile(filePath)).to.throw(/no such file/);
+            expect(() => deleteFile(filePath)).toThrow(/no such file/);
         });
     });
 
@@ -89,8 +89,8 @@ describe('file-util', () => {
 
             moveFile(filePath, destDir);
 
-            expect(fs.existsSync(path.join(destDir, 'source.txt'))).to.be.true;
-            expect(fs.existsSync(filePath)).to.be.false;
+            expect(fs.existsSync(path.join(destDir, 'source.txt'))).toBe(true);
+            expect(fs.existsSync(filePath)).toBe(false);
         });
     });
 
@@ -99,7 +99,7 @@ describe('file-util', () => {
             const filePath = path.join(tempDir, 'bad.json');
             fs.writeFileSync(filePath, '{ not valid json }', 'utf8');
 
-            expect(() => readJson(filePath)).to.throw(/Failed to parse JSON/);
+            expect(() => readJson(filePath)).toThrow(/Failed to parse JSON/);
         });
     });
 
@@ -111,7 +111,7 @@ describe('file-util', () => {
             replaceInFile(filePath, 'world', 'universe');
 
             const result = fs.readFileSync(filePath, 'utf8');
-            expect(result).to.equal('hello universe');
+            expect(result).toBe('hello universe');
         });
 
         it('should replace a regex pattern in a file', () => {
@@ -121,7 +121,7 @@ describe('file-util', () => {
             replaceInFile(filePath, /\d+/, 'NUM');
 
             const result = fs.readFileSync(filePath, 'utf8');
-            expect(result).to.equal('fooNUMbar');
+            expect(result).toBe('fooNUMbar');
         });
     });
 
@@ -134,8 +134,8 @@ describe('file-util', () => {
 
             const result = filterFiles([matchFile, noMatchFile], 'hello');
 
-            expect(result).to.have.lengthOf(1);
-            expect(result[0]).to.equal(path.resolve(matchFile));
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(path.resolve(matchFile));
         });
     });
 });

--- a/dev-packages/cli/src/util/git-util.spec.ts
+++ b/dev-packages/cli/src/util/git-util.spec.ts
@@ -37,49 +37,49 @@ describe('git-util', () => {
         it('should parse porcelain output into file paths', () => {
             execStub.mockReturnValue(' M src/file.ts\n?? new-file.ts');
             const result = getUncommittedChanges('/repo');
-            expect(result).to.have.length(2);
+            expect(result).toHaveLength(2);
         });
 
         it('should return empty array for empty output', () => {
             execStub.mockReturnValue('');
             const result = getUncommittedChanges('/repo');
-            expect(result).to.have.length(0);
+            expect(result).toHaveLength(0);
         });
     });
 
     describe('hasChanges', () => {
         it('should return true when there are uncommitted changes', () => {
             execStub.mockReturnValue(' M src/file.ts\n?? new-file.ts');
-            expect(hasChanges('/repo')).to.be.true;
+            expect(hasChanges('/repo')).toBe(true);
         });
 
         it('should return false when there are no changes', () => {
             execStub.mockReturnValue('');
-            expect(hasChanges('/repo')).to.be.false;
+            expect(hasChanges('/repo')).toBe(false);
         });
     });
 
     describe('commitChanges', () => {
         it('should escape double quotes in commit message', () => {
             commitChanges('fix "bug"', '/repo');
-            expect(execStub.mock.calls[1][0]).to.contain('\\"');
+            expect(execStub.mock.calls[1][0]).toContain('\\"');
         });
 
         it('should escape backslashes in commit message', () => {
             commitChanges('path\\to\\file', '/repo');
-            expect(execStub.mock.calls[1][0]).to.contain('\\\\');
+            expect(execStub.mock.calls[1][0]).toContain('\\\\');
         });
     });
 
     describe('getDefaultBranch', () => {
         it('should parse HEAD branch from remote output', () => {
             execStub.mockReturnValue('* remote origin\n  HEAD branch: main\n  Remote branches:');
-            expect(getDefaultBranch('/repo')).to.equal('main');
+            expect(getDefaultBranch('/repo')).toBe('main');
         });
 
         it('should fallback to master when HEAD branch is not found', () => {
             execStub.mockReturnValue('* remote origin\n  Remote branches:');
-            expect(getDefaultBranch('/repo')).to.equal('master');
+            expect(getDefaultBranch('/repo')).toBe('master');
         });
     });
 
@@ -89,7 +89,7 @@ describe('git-util', () => {
                 if (/symbolic-ref/.test(cmd)) return 'origin/develop';
                 return '';
             });
-            expect(getDefaultBranchRef('/repo')).to.equal('origin/develop');
+            expect(getDefaultBranchRef('/repo')).toBe('origin/develop');
         });
 
         it('should fall back to the first existing candidate ref', () => {
@@ -100,14 +100,14 @@ describe('git-util', () => {
                 if (/--verify --quiet main/.test(cmd)) return '';
                 return '';
             });
-            expect(getDefaultBranchRef('/repo')).to.equal('main');
+            expect(getDefaultBranchRef('/repo')).toBe('main');
         });
 
         it('should return undefined when no default branch can be determined', () => {
             execStub.mockImplementation(() => {
                 throw new Error('not a git repository');
             });
-            expect(getDefaultBranchRef('/repo')).to.be.undefined;
+            expect(getDefaultBranchRef('/repo')).toBeUndefined();
         });
     });
 
@@ -120,8 +120,8 @@ describe('git-util', () => {
                 return '';
             });
             const result = getChangesComparedToDefaultBranch('/repo');
-            expect(result).to.have.members(['/repo/src/a.ts', '/repo/src/b.ts', '/repo/src/c.ts']);
-            expect(result).to.have.length(3);
+            expect(result).toEqual(expect.arrayContaining(['/repo/src/a.ts', '/repo/src/b.ts', '/repo/src/c.ts']));
+            expect(result).toHaveLength(3);
         });
 
         it('should only consider uncommitted changes when no default branch is found', () => {
@@ -130,7 +130,7 @@ describe('git-util', () => {
                 throw new Error('not a git repository');
             });
             const result = getChangesComparedToDefaultBranch('/repo');
-            expect(result).to.deep.equal(['/repo/src/only.ts']);
+            expect(result).toEqual(['/repo/src/only.ts']);
         });
     });
 
@@ -138,13 +138,13 @@ describe('git-util', () => {
         it('should return a Date for a valid date string', () => {
             execStub.mockReturnValue('2024-01-15 10:30:00 +0000');
             const result = getLastModificationDate('file.ts', '/repo');
-            expect(result).to.be.an.instanceOf(Date);
+            expect(result).toBeInstanceOf(Date);
         });
 
         it('should return undefined for empty result', () => {
             execStub.mockReturnValue('');
             const result = getLastModificationDate('file.ts', '/repo');
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
 
         it('should return undefined when exec throws', () => {
@@ -152,7 +152,7 @@ describe('git-util', () => {
                 throw new Error('git error');
             });
             const result = getLastModificationDate('file.ts', '/repo');
-            expect(result).to.be.undefined;
+            expect(result).toBeUndefined();
         });
     });
 });

--- a/dev-packages/cli/src/util/glsp-repo-util.spec.ts
+++ b/dev-packages/cli/src/util/glsp-repo-util.spec.ts
@@ -23,31 +23,31 @@ describe('repo-filter', () => {
 
         it('should return configured repos when no filter is specified', () => {
             const result = resolveRepoFilter(configuredRepos, {});
-            expect(result).to.deep.equal(configuredRepos);
+            expect(result).toEqual(configuredRepos);
         });
 
         it('should filter to specific repos with --repo', () => {
             const result = resolveRepoFilter(configuredRepos, { repo: ['glsp-client'] });
-            expect(result).to.deep.equal(['glsp-client']);
+            expect(result).toEqual(['glsp-client']);
         });
 
         it('should allow repos not in config with --repo', () => {
             const result = resolveRepoFilter(configuredRepos, { repo: ['glsp-playwright'] });
-            expect(result).to.deep.equal(['glsp-playwright']);
+            expect(result).toEqual(['glsp-playwright']);
         });
 
         it('should expand preset with --preset', () => {
             const result = resolveRepoFilter(configuredRepos, { preset: 'core' });
-            expect(result).to.include('glsp-client');
-            expect(result).to.include('glsp-server-node');
+            expect(result).toContain('glsp-client');
+            expect(result).toContain('glsp-server-node');
         });
 
         it('should throw for unknown preset', () => {
-            expect(() => resolveRepoFilter(configuredRepos, { preset: 'nonexistent' })).to.throw(/Unknown preset/);
+            expect(() => resolveRepoFilter(configuredRepos, { preset: 'nonexistent' })).toThrow(/Unknown preset/);
         });
 
         it('should throw for unknown repo name', () => {
-            expect(() => resolveRepoFilter(configuredRepos, { repo: ['not-a-repo'] })).to.throw(/Unknown repository/);
+            expect(() => resolveRepoFilter(configuredRepos, { repo: ['not-a-repo'] })).toThrow(/Unknown repository/);
         });
     });
 });

--- a/dev-packages/cli/src/util/package-util.spec.ts
+++ b/dev-packages/cli/src/util/package-util.spec.ts
@@ -38,19 +38,19 @@ describe('package-util', () => {
         });
 
         it('should throw if the path does not point to a package.json file', () => {
-            expect(() => new PackageHelper(path.join(tempDir, 'other.json'), 'test')).to.throw(/must point to a package.json/);
+            expect(() => new PackageHelper(path.join(tempDir, 'other.json'), 'test')).toThrow(/must point to a package.json/);
         });
 
         it('should throw if the package.json file does not exist', () => {
-            expect(() => new PackageHelper(path.join(tempDir, 'package.json'), 'test')).to.throw(/No package.json found/);
+            expect(() => new PackageHelper(path.join(tempDir, 'package.json'), 'test')).toThrow(/No package.json found/);
         });
 
         it('should succeed when the path points to an existing package.json', () => {
             const packageJsonPath = path.join(tempDir, 'package.json');
             fs.writeFileSync(packageJsonPath, JSON.stringify({ name: 'test-pkg', version: '1.0.0' }));
             const helper = new PackageHelper(packageJsonPath, 'test-pkg');
-            expect(helper.filePath).to.equal(packageJsonPath);
-            expect(helper.name).to.equal('test-pkg');
+            expect(helper.filePath).toBe(packageJsonPath);
+            expect(helper.name).toBe('test-pkg');
         });
     });
 
@@ -84,8 +84,8 @@ describe('package-util', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue(listOutput);
 
             const packages = getWorkspacePackages(tempDir);
-            expect(packages.map(pkg => pkg.name)).to.deep.equal(['@scope/pkg-a', '@scope/pkg-b']);
-            expect(packages.map(pkg => pkg.location)).to.deep.equal([pkgADir, pkgBDir]);
+            expect(packages.map(pkg => pkg.name)).toEqual(['@scope/pkg-a', '@scope/pkg-b']);
+            expect(packages.map(pkg => pkg.location)).toEqual([pkgADir, pkgBDir]);
         });
 
         it('should append the root package if includeRoot is set', () => {
@@ -98,8 +98,8 @@ describe('package-util', () => {
             vi.spyOn(processUtil, 'exec').mockReturnValue(listOutput);
 
             const packages = getWorkspacePackages(tempDir, true);
-            expect(packages.map(pkg => pkg.name)).to.deep.equal(['@scope/pkg-a', 'root']);
-            expect(packages[packages.length - 1].location).to.equal(tempDir);
+            expect(packages.map(pkg => pkg.name)).toEqual(['@scope/pkg-a', 'root']);
+            expect(packages[packages.length - 1].location).toBe(tempDir);
         });
     });
 });

--- a/dev-packages/cli/src/util/process-util.spec.ts
+++ b/dev-packages/cli/src/util/process-util.spec.ts
@@ -25,25 +25,25 @@ describe('process-util', () => {
     describe('exec', () => {
         it('should return trimmed stdout on success', () => {
             const result = exec('echo hello');
-            expect(result).to.equal('hello');
+            expect(result).toBe('hello');
         });
 
         it('should throw on non-zero exit code', () => {
-            expect(() => exec('sh -c "exit 1"')).to.throw(/Command failed/);
+            expect(() => exec('sh -c "exit 1"')).toThrow(/Command failed/);
         });
 
         it('should use custom error message when provided', () => {
-            expect(() => exec('sh -c "exit 1"', { errorMsg: 'Custom error' })).to.throw('Custom error');
+            expect(() => exec('sh -c "exit 1"', { errorMsg: 'Custom error' })).toThrow('Custom error');
         });
 
         it('should pass cwd option', () => {
             const result = exec('pwd', { cwd: '/tmp' });
-            expect(result).to.include('tmp');
+            expect(result).toContain('tmp');
         });
 
         it('should return empty string for command with no output', () => {
             const result = exec('true');
-            expect(result).to.equal('');
+            expect(result).toBe('');
         });
     });
 
@@ -57,7 +57,7 @@ describe('process-util', () => {
                 await execForeground('sh -c "exit 1"');
                 expect.fail('should have thrown');
             } catch (error) {
-                expect((error as Error).message).to.contain('exited with code 1');
+                expect((error as Error).message).toContain('exited with code 1');
             }
         });
 

--- a/dev-packages/cli/src/util/validation-util.spec.ts
+++ b/dev-packages/cli/src/util/validation-util.spec.ts
@@ -35,25 +35,25 @@ describe('validation-util', () => {
     describe('validateDirectory', () => {
         it('should return the resolved path for a valid directory', () => {
             const result = validateDirectory(tempDir);
-            expect(result).to.equal(path.resolve(tempDir));
+            expect(result).toBe(path.resolve(tempDir));
         });
 
         it('should throw for a non-existent path', () => {
             const nonExistent = path.join(tempDir, 'does-not-exist');
-            expect(() => validateDirectory(nonExistent)).to.throw(/Not a valid file path/);
+            expect(() => validateDirectory(nonExistent)).toThrow(/Not a valid file path/);
         });
 
         it('should throw for a file path (not a directory)', () => {
             const filePath = path.join(tempDir, 'test-file.txt');
             fs.writeFileSync(filePath, 'content');
-            expect(() => validateDirectory(filePath)).to.throw(/Not a directory/);
+            expect(() => validateDirectory(filePath)).toThrow(/Not a directory/);
         });
     });
 
     describe('validateFile', () => {
         it('should throw for a non-existent file when hasToExist is true', () => {
             const nonExistent = path.join(tempDir, 'missing-file.txt');
-            expect(() => validateFile(nonExistent, true)).to.throw(/Not a valid file path/);
+            expect(() => validateFile(nonExistent, true)).toThrow(/Not a valid file path/);
         });
     });
 
@@ -62,12 +62,12 @@ describe('validation-util', () => {
             vi.spyOn(gitUtil, 'isGitRepository').mockReturnValue(true);
             vi.spyOn(gitUtil, 'getGitRoot').mockReturnValue('/resolved/root');
             const result = validateGitDirectory(tempDir);
-            expect(result).to.equal('/resolved/root');
+            expect(result).toBe('/resolved/root');
         });
 
         it('should throw for a directory that is not a git repository', () => {
             vi.spyOn(gitUtil, 'isGitRepository').mockReturnValue(false);
-            expect(() => validateGitDirectory(tempDir)).to.throw(/Not a valid git repository/);
+            expect(() => validateGitDirectory(tempDir)).toThrow(/Not a valid git repository/);
         });
     });
 });

--- a/dev-packages/cli/tests/e2e/check-header.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/check-header.e2e.spec.ts
@@ -53,32 +53,32 @@ describe('checkHeaders e2e', () => {
     it('should pass for files with valid headers', () => {
         commitFile(repoDir, 'src/good.ts', VALID_HEADER + '\nconst x = 1;\n', 'add valid file');
         const result = runCli(['checkHeaders', repoDir]);
-        expect(result.exitCode).to.equal(0);
-        expect(result.stdout).to.contain('0 copyright header violations');
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('0 copyright header violations');
     });
 
     it('should detect files with missing headers', () => {
         commitFile(repoDir, 'src/bad.ts', 'const x = 1;\n', 'add file without header');
         const result = runCli(['checkHeaders', repoDir]);
-        expect(result.exitCode).to.not.equal(0);
+        expect(result.exitCode).not.toBe(0);
     });
 
     it('should auto-fix invalid headers with --autoFix', () => {
         const outdatedHeader = VALID_HEADER.replace(String(new Date().getFullYear()), '2020');
         commitFile(repoDir, 'src/outdated.ts', outdatedHeader + '\nconst x = 1;\n', 'add outdated file');
         const result = runCli(['checkHeaders', repoDir, '--autoFix']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const content = fs.readFileSync(path.join(repoDir, 'src/outdated.ts'), 'utf8');
-        expect(content).to.contain(String(new Date().getFullYear()));
+        expect(content).toContain(String(new Date().getFullYear()));
     });
 
     it('should create a git commit with --autoFix --commit', () => {
         const outdatedHeader = VALID_HEADER.replace(String(new Date().getFullYear()), '2020');
         commitFile(repoDir, 'src/outdated.ts', outdatedHeader + '\nconst x = 1;\n', 'add outdated file');
         const result = runCli(['checkHeaders', repoDir, '--autoFix', '--commit']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const log = execSync('git log --oneline', { cwd: repoDir, encoding: 'utf-8' });
-        expect(log).to.contain('Fix copyright header violations');
+        expect(log).toContain('Fix copyright header violations');
     });
 
     it('should only check changed files with --type changes', () => {
@@ -87,7 +87,7 @@ describe('checkHeaders e2e', () => {
         fs.writeFileSync(path.join(repoDir, 'src/new.ts'), 'const y = 2;\n');
         execSync('git add .', { cwd: repoDir });
         const result = runCli(['checkHeaders', repoDir, '--type', 'changes']);
-        expect(result.stdout).to.contain('1 copyright header violations');
+        expect(result.stdout).toContain('1 copyright header violations');
     });
 
     it('should check files changed against the default branch with --type changes', () => {
@@ -96,16 +96,16 @@ describe('checkHeaders e2e', () => {
         execSync('git checkout -b feature', { cwd: repoDir });
         commitFile(repoDir, 'src/feature.ts', 'const y = 2;\n', 'add feature file');
         const result = runCli(['checkHeaders', repoDir, '--type', 'changes']);
-        expect(result.stdout).to.contain('Check copy right headers of 1 files');
-        expect(result.stdout).to.contain('feature.ts');
-        expect(result.stdout).to.not.contain('base.ts');
+        expect(result.stdout).toContain('Check copy right headers of 1 files');
+        expect(result.stdout).toContain('feature.ts');
+        expect(result.stdout).not.toContain('base.ts');
     });
 
     it('should only check last commit files with --type lastCommit', () => {
         commitFile(repoDir, 'src/old.ts', VALID_HEADER + '\nconst x = 1;\n', 'add old file');
         commitFile(repoDir, 'src/new.ts', 'const y = 2;\n', 'add new file');
         const result = runCli(['checkHeaders', repoDir, '--type', 'lastCommit']);
-        expect(result.stdout).to.contain('Check copy right headers of 1 files');
+        expect(result.stdout).toContain('Check copy right headers of 1 files');
     });
 
     describe('with a repository under a dot-directory', () => {
@@ -126,16 +126,16 @@ describe('checkHeaders e2e', () => {
             execSync('git checkout -b feature', { cwd: hiddenRepoDir });
             commitFile(hiddenRepoDir, 'src/feature.ts', 'const y = 2;\n', 'add feature file');
             const result = runCli(['checkHeaders', hiddenRepoDir, '--type', 'changes']);
-            expect(result.stdout).to.contain('Check copy right headers of 1 files');
-            expect(result.stdout).to.contain('feature.ts');
-            expect(result.stdout).to.not.contain('base.ts');
+            expect(result.stdout).toContain('Check copy right headers of 1 files');
+            expect(result.stdout).toContain('feature.ts');
+            expect(result.stdout).not.toContain('base.ts');
         });
 
         it('should still detect changed files with --type lastCommit', () => {
             commitFile(hiddenRepoDir, 'src/old.ts', VALID_HEADER + '\nconst x = 1;\n', 'add old file');
             commitFile(hiddenRepoDir, 'src/new.ts', 'const y = 2;\n', 'add new file');
             const result = runCli(['checkHeaders', hiddenRepoDir, '--type', 'lastCommit']);
-            expect(result.stdout).to.contain('Check copy right headers of 1 files');
+            expect(result.stdout).toContain('Check copy right headers of 1 files');
         });
     });
 
@@ -143,29 +143,29 @@ describe('checkHeaders e2e', () => {
         commitFile(repoDir, 'src/script.js', 'const x = 1;\n', 'add js file');
         commitFile(repoDir, 'src/good.ts', VALID_HEADER + '\nconst y = 2;\n', 'add ts file');
         const result = runCli(['checkHeaders', repoDir, '--fileExtensions', 'js']);
-        expect(result.stdout).to.contain('Check copy right headers of 1 files');
+        expect(result.stdout).toContain('Check copy right headers of 1 files');
     });
 
     it('should exclude files matching --exclude pattern', () => {
         commitFile(repoDir, 'src/main.ts', 'const x = 1;\n', 'add main');
         commitFile(repoDir, 'src/generated/output.ts', 'const y = 2;\n', 'add generated');
         const result = runCli(['checkHeaders', repoDir, '--exclude', '**/generated/**']);
-        expect(result.stdout).to.not.contain('generated/output.ts');
+        expect(result.stdout).not.toContain('generated/output.ts');
     });
 
     it('should accept --no-exclude-defaults flag', () => {
         commitFile(repoDir, 'src/main.ts', VALID_HEADER + '\nconst y = 2;\n', 'add main');
         const result = runCli(['checkHeaders', repoDir, '--no-exclude-defaults']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
     });
 
     it('should write results to JSON file with --json', () => {
         commitFile(repoDir, 'src/good.ts', VALID_HEADER + '\nconst x = 1;\n', 'add valid file');
         const result = runCli(['checkHeaders', repoDir, '--json']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const jsonPath = path.join(repoDir, 'headerCheck.json');
-        expect(fs.existsSync(jsonPath)).to.equal(true);
+        expect(fs.existsSync(jsonPath)).toBe(true);
         const jsonContent = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-        expect(jsonContent).to.be.an('array');
+        expect(Array.isArray(jsonContent)).toBe(true);
     });
 });

--- a/dev-packages/cli/tests/e2e/generate-index.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/generate-index.e2e.spec.ts
@@ -35,18 +35,18 @@ describe('generateIndex e2e', () => {
         fs.writeFileSync(path.join(tempDir, 'foo.ts'), 'export const foo = 1;\n');
         fs.writeFileSync(path.join(tempDir, 'bar.ts'), 'export const bar = 2;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const indexContent = fs.readFileSync(path.join(tempDir, 'index.ts'), 'utf8');
-        expect(indexContent).to.contain("export * from './bar';");
-        expect(indexContent).to.contain("export * from './foo';");
+        expect(indexContent).toContain("export * from './bar';");
+        expect(indexContent).toContain("export * from './foo';");
     });
 
     it('should use ESM style exports with --style esm', () => {
         fs.writeFileSync(path.join(tempDir, 'module.ts'), 'export const m = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite', '--style', 'esm']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const indexContent = fs.readFileSync(path.join(tempDir, 'index.ts'), 'utf8');
-        expect(indexContent).to.contain("export * from './module.js';");
+        expect(indexContent).toContain("export * from './module.js';");
     });
 
     it('should generate nested indices without --singleIndex', () => {
@@ -55,9 +55,9 @@ describe('generateIndex e2e', () => {
         fs.writeFileSync(path.join(subDir, 'nested.ts'), 'export const n = 1;\n');
         fs.writeFileSync(path.join(tempDir, 'root.ts'), 'export const r = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite']);
-        expect(result.exitCode).to.equal(0);
-        expect(fs.existsSync(path.join(tempDir, 'index.ts'))).to.equal(true);
-        expect(fs.existsSync(path.join(subDir, 'index.ts'))).to.equal(true);
+        expect(result.exitCode).toBe(0);
+        expect(fs.existsSync(path.join(tempDir, 'index.ts'))).toBe(true);
+        expect(fs.existsSync(path.join(subDir, 'index.ts'))).toBe(true);
     });
 
     it('should generate a single root index with --singleIndex', () => {
@@ -66,29 +66,29 @@ describe('generateIndex e2e', () => {
         fs.writeFileSync(path.join(subDir, 'nested.ts'), 'export const n = 1;\n');
         fs.writeFileSync(path.join(tempDir, 'root.ts'), 'export const r = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite', '--singleIndex']);
-        expect(result.exitCode).to.equal(0);
-        expect(fs.existsSync(path.join(tempDir, 'index.ts'))).to.equal(true);
-        expect(fs.existsSync(path.join(subDir, 'index.ts'))).to.equal(false);
+        expect(result.exitCode).toBe(0);
+        expect(fs.existsSync(path.join(tempDir, 'index.ts'))).toBe(true);
+        expect(fs.existsSync(path.join(subDir, 'index.ts'))).toBe(false);
     });
 
     it('should only index files matching custom --match pattern', () => {
         fs.writeFileSync(path.join(tempDir, 'code.ts'), 'export const c = 1;\n');
         fs.writeFileSync(path.join(tempDir, 'script.js'), 'export const s = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite', '--match', '**/*.js']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const indexContent = fs.readFileSync(path.join(tempDir, 'index.ts'), 'utf8');
-        expect(indexContent).to.contain("'./script'");
-        expect(indexContent).to.not.contain("'./code'");
+        expect(indexContent).toContain("'./script'");
+        expect(indexContent).not.toContain("'./code'");
     });
 
     it('should exclude files matching custom --ignore pattern', () => {
         fs.writeFileSync(path.join(tempDir, 'keep.ts'), 'export const k = 1;\n');
         fs.writeFileSync(path.join(tempDir, 'skip.test.ts'), 'export const s = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite', '--ignore', '**/*.test.ts']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const indexContent = fs.readFileSync(path.join(tempDir, 'index.ts'), 'utf8');
-        expect(indexContent).to.contain("'./keep'");
-        expect(indexContent).to.not.contain("'./skip.test'");
+        expect(indexContent).toContain("'./keep'");
+        expect(indexContent).not.toContain("'./skip.test'");
     });
 
     it('should respect .indexignore file', () => {
@@ -96,17 +96,17 @@ describe('generateIndex e2e', () => {
         fs.writeFileSync(path.join(tempDir, 'excluded.ts'), 'export const e = 1;\n');
         fs.writeFileSync(path.join(tempDir, '.indexignore'), 'excluded.ts\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const indexContent = fs.readFileSync(path.join(tempDir, 'index.ts'), 'utf8');
-        expect(indexContent).to.contain("'./included'");
-        expect(indexContent).to.not.contain("'./excluded'");
+        expect(indexContent).toContain("'./included'");
+        expect(indexContent).not.toContain("'./excluded'");
     });
 
     it('should produce extra output with --verbose', () => {
         fs.writeFileSync(path.join(tempDir, 'mod.ts'), 'export const m = 1;\n');
         const result = runCli(['generateIndex', tempDir, '--forceOverwrite', '--verbose']);
-        expect(result.exitCode).to.equal(0);
+        expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
-        expect(output).to.contain('generateIndex');
+        expect(output).toContain('generateIndex');
     });
 });

--- a/dev-packages/cli/tests/e2e/releng/prepare.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/releng/prepare.e2e.spec.ts
@@ -155,30 +155,30 @@ describe('releng prepare — glsp', function () {
         const result = runCli(['releng', 'prepare', 'custom', '99.0.0', '--no-push', '--no-check', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Release branch created
         const branches = git('branch', repoDir);
-        expect(branches).to.contain('release-v99.0.0');
+        expect(branches).toContain('release-v99.0.0');
 
         // Version bumped in root package.json
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
-        expect(rootPkg.version).to.equal('99.0.0');
+        expect(rootPkg.version).toBe('99.0.0');
 
         // At least one workspace package.json updated
         const workspacePkgs = findWorkspacePackageJsons(repoDir);
-        expect(workspacePkgs.length).to.be.greaterThan(0);
+        expect(workspacePkgs.length).toBeGreaterThan(0);
         const firstPkg = readJson(workspacePkgs[0]);
-        expect(firstPkg.version).to.equal('99.0.0');
+        expect(firstPkg.version).toBe('99.0.0');
 
         // CHANGELOG.md updated
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-        expect(changelog).to.not.contain('## v99.0.0 - active');
-        expect(changelog).to.contain('## [v99.0.0 -');
+        expect(changelog).not.toContain('## v99.0.0 - active');
+        expect(changelog).toContain('## [v99.0.0 -');
 
         // Git commit created
         const logMsg = git('log -1 --pretty=%s', repoDir);
-        expect(logMsg).to.equal('v99.0.0');
+        expect(logMsg).toBe('v99.0.0');
     });
 });
 
@@ -218,29 +218,29 @@ for (const repo of NPM_REPOS_WITH_EXTERNAL_DEPS) {
             const result = runCli(['releng', 'prepare', 'next', '--no-push', '--no-check', '-r', repoDir], {
                 timeout: 0
             });
-            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
             // Nightly branch created (nightly-X.Y.0-next)
             const branches = git('branch', repoDir);
-            expect(branches).to.match(/nightly-\d+\.\d+\.0-next/);
+            expect(branches).toMatch(/nightly-\d+\.\d+\.0-next/);
 
             // Version bumped with -next suffix
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
-            expect(rootPkg.version as string).to.match(/-next$/);
+            expect(rootPkg.version as string).toMatch(/-next$/);
 
             // At least one workspace package.json updated
             const workspacePkgs = findWorkspacePackageJsons(repoDir);
-            expect(workspacePkgs.length).to.be.greaterThan(0);
+            expect(workspacePkgs.length).toBeGreaterThan(0);
             const firstPkg = readJson(workspacePkgs[0]);
-            expect(firstPkg.version as string).to.match(/-next$/);
+            expect(firstPkg.version as string).toMatch(/-next$/);
 
             // CHANGELOG.md should have a new active section
             const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-            expect(changelog).to.match(/## v\d+\.\d+\.0 - active/);
+            expect(changelog).toMatch(/## v\d+\.\d+\.0 - active/);
 
             // Git commit message
             const logMsg = git('log -1 --pretty=%s', repoDir);
-            expect(logMsg).to.match(/^Switch to nightly \d+\.\d+\.0-next versions$/);
+            expect(logMsg).toMatch(/^Switch to nightly \d+\.\d+\.0-next versions$/);
         });
     });
 }
@@ -273,23 +273,23 @@ describe('releng prepare — glsp-playwright', function () {
         const result = runCli(['releng', 'prepare', 'next', '--no-push', '--no-check', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Nightly branch created
         const branches = git('branch', repoDir);
-        expect(branches).to.match(/nightly-\d+\.\d+\.0-next/);
+        expect(branches).toMatch(/nightly-\d+\.\d+\.0-next/);
 
         // Version bumped with -next suffix
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
-        expect(rootPkg.version as string).to.match(/-next$/);
+        expect(rootPkg.version as string).toMatch(/-next$/);
 
         // CHANGELOG.md should have a new active section
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-        expect(changelog).to.match(/## v\d+\.\d+\.0 - active/);
+        expect(changelog).toMatch(/## v\d+\.\d+\.0 - active/);
 
         // Git commit message
         const logMsg = git('log -1 --pretty=%s', repoDir);
-        expect(logMsg).to.match(/^Switch to nightly \d+\.\d+\.0-next versions$/);
+        expect(logMsg).toMatch(/^Switch to nightly \d+\.\d+\.0-next versions$/);
     });
 });
 
@@ -322,11 +322,11 @@ describe('releng prepare — glsp-client (extended)', function () {
         const result = runCli(['releng', 'prepare', 'next', '--no-push', '--no-check', '--verbose', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Verbose mode produces debug output
         const combined = result.stdout + result.stderr;
-        expect(combined).to.contain('Bump version');
+        expect(combined).toContain('Bump version');
     });
 
     it('should push --draft release to local bare remote', function () {
@@ -338,10 +338,10 @@ describe('releng prepare — glsp-client (extended)', function () {
 
         // gh pr create will fail, so exit code is non-zero. But verify push happened.
         const remoteBranches = git('branch', bareDir);
-        expect(remoteBranches).to.match(/nightly-\d+\.\d+\.0-next/);
+        expect(remoteBranches).toMatch(/nightly-\d+\.\d+\.0-next/);
 
         // Regardless of exit code, the test exercises the push + draft path
-        expect(result).to.not.equal(undefined);
+        expect(result).not.toBe(undefined);
     });
 });
 
@@ -373,27 +373,27 @@ describe('releng prepare — glsp-theia-integration', function () {
         const result = runCli(['releng', 'prepare', 'next', '--no-push', '--no-check', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Nightly branch created
         const branches = git('branch', repoDir);
-        expect(branches).to.match(/nightly-\d+\.\d+\.0-next/);
+        expect(branches).toMatch(/nightly-\d+\.\d+\.0-next/);
 
         // NPM checks
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
-        expect(rootPkg.version as string).to.match(/-next$/);
+        expect(rootPkg.version as string).toMatch(/-next$/);
 
         // Theia README compatibility table should contain 'next'
         const readme = readText(path.join(repoDir, 'README.md'));
-        expect(readme).to.contain('next');
+        expect(readme).toContain('next');
 
         // CHANGELOG.md should have a new active section
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-        expect(changelog).to.match(/## v\d+\.\d+\.0 - active/);
+        expect(changelog).toMatch(/## v\d+\.\d+\.0 - active/);
 
         // Git commit message
         const logMsg = git('log -1 --pretty=%s', repoDir);
-        expect(logMsg).to.match(/^Switch to nightly \d+\.\d+\.0-next versions$/);
+        expect(logMsg).toMatch(/^Switch to nightly \d+\.\d+\.0-next versions$/);
     });
 });
 
@@ -429,24 +429,24 @@ describe.skipIf(!isMavenAvailable())('releng prepare — glsp-server', function 
         const result = runCli(['releng', 'prepare', 'custom', '99.0.0', '--no-push', '--no-check', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Release branch created
         const branches = git('branch', repoDir);
-        expect(branches).to.contain('release-v99.0.0');
+        expect(branches).toContain('release-v99.0.0');
 
         // Version bumped in pom.xml
         const pom = readText(path.join(repoDir, 'pom.xml'));
-        expect(pom).to.contain('<version>99.0.0</version>');
+        expect(pom).toContain('<version>99.0.0</version>');
 
         // CHANGELOG.md updated
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-        expect(changelog).to.not.contain('## v99.0.0 - active');
-        expect(changelog).to.contain('## [v99.0.0 -');
+        expect(changelog).not.toContain('## v99.0.0 - active');
+        expect(changelog).toContain('## [v99.0.0 -');
 
         // Git commit created
         const logMsg = git('log -1 --pretty=%s', repoDir);
-        expect(logMsg).to.equal('v99.0.0');
+        expect(logMsg).toBe('v99.0.0');
     });
 });
 
@@ -480,26 +480,26 @@ describe.skipIf(!isMavenAvailable())('releng prepare — glsp-eclipse-integratio
         const result = runCli(['releng', 'prepare', 'next', '--no-push', '--no-check', '-r', repoDir], {
             timeout: 0
         });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Nightly branch created
         const branches = git('branch', repoDir);
-        expect(branches).to.match(/nightly-\d+\.\d+\.0-next/);
+        expect(branches).toMatch(/nightly-\d+\.\d+\.0-next/);
 
         // Client npm packages get the -next suffix
         const clientPkg = readJson(path.join(repoDir, 'client', 'package.json'));
-        expect(clientPkg.version as string).to.match(/-next$/);
+        expect(clientPkg.version as string).toMatch(/-next$/);
 
         // Server pom.xml gets a SNAPSHOT version
         const serverPom = readText(path.join(repoDir, 'server', 'pom.xml'));
-        expect(serverPom).to.match(/<version>\d+\.\d+\.0-SNAPSHOT<\/version>/);
+        expect(serverPom).toMatch(/<version>\d+\.\d+\.0-SNAPSHOT<\/version>/);
 
         // CHANGELOG.md has a new active section added
         const changelog = readText(path.join(repoDir, 'CHANGELOG.md'));
-        expect(changelog).to.match(/## v\d+\.\d+\.0 - active/);
+        expect(changelog).toMatch(/## v\d+\.\d+\.0 - active/);
 
         // Git commit message for nightly
         const logMsg = git('log -1 --pretty=%s', repoDir);
-        expect(logMsg).to.match(/^Switch to nightly \d+\.\d+\.0-next versions$/);
+        expect(logMsg).toMatch(/^Switch to nightly \d+\.\d+\.0-next versions$/);
     });
 });

--- a/dev-packages/cli/tests/e2e/releng/version.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/releng/version.e2e.spec.ts
@@ -71,31 +71,31 @@ for (const repo of NPM_REPOS) {
 
         it(`should set custom version 99.0.0`, function () {
             const result = runCli(['releng', 'version', 'custom', '99.0.0', '-r', repoDir], { timeout: 0 });
-            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
             // Root package.json
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
-            expect(rootPkg.version).to.equal('99.0.0');
+            expect(rootPkg.version).toBe('99.0.0');
 
             // At least one workspace package.json updated
             const workspacePkgs = findWorkspacePackageJsons(repoDir);
-            expect(workspacePkgs.length).to.be.greaterThan(0);
+            expect(workspacePkgs.length).toBeGreaterThan(0);
             const firstPkg = readJson(workspacePkgs[0]);
-            expect(firstPkg.version).to.equal('99.0.0');
+            expect(firstPkg.version).toBe('99.0.0');
         });
 
         it(`should set next version`, function () {
             const result = runCli(['releng', 'version', 'next', '-r', repoDir], { timeout: 0 });
-            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+            expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
             const rootPkg = readJson(path.join(repoDir, 'package.json'));
-            expect(rootPkg.version as string).to.match(/-next$/);
+            expect(rootPkg.version as string).toMatch(/-next$/);
 
             // At least one workspace package.json updated
             const workspacePkgs = findWorkspacePackageJsons(repoDir);
-            expect(workspacePkgs.length).to.be.greaterThan(0);
+            expect(workspacePkgs.length).toBeGreaterThan(0);
             const firstPkg = readJson(workspacePkgs[0]);
-            expect(firstPkg.version as string).to.match(/-next$/);
+            expect(firstPkg.version as string).toMatch(/-next$/);
         });
     });
 }
@@ -122,27 +122,27 @@ describe('releng version — glsp-client (extended)', function () {
         const origVersion = origPkg.version as string;
 
         const result = runCli(['releng', 'version', 'minor', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         const updatedPkg = readJson(path.join(repoDir, 'package.json'));
         const newVersion = updatedPkg.version as string;
-        expect(newVersion).to.not.equal(origVersion);
+        expect(newVersion).not.toBe(origVersion);
 
         // New version should be a clean semver without pre-release suffix
         // and its minor component should be >= the original base minor
         const origMinor = parseInt(origVersion.replace(/-.*$/, '').split('.')[1], 10);
         const newMinor = parseInt(newVersion.split('.')[1], 10);
-        expect(newMinor).to.be.greaterThanOrEqual(origMinor);
-        expect(newVersion).to.not.contain('-');
+        expect(newMinor).toBeGreaterThanOrEqual(origMinor);
+        expect(newVersion).not.toContain('-');
     });
 
     it('should accept --verbose flag', function () {
         const result = runCli(['releng', 'version', 'custom', '99.0.0', '--verbose', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Verbose mode produces debug output
         const combined = result.stdout + result.stderr;
-        expect(combined).to.contain('Bump version');
+        expect(combined).toContain('Bump version');
     });
 });
 
@@ -165,31 +165,31 @@ describe('releng version — glsp-theia-integration', function () {
 
     it('should set custom version 99.0.0 and update Theia README', function () {
         const result = runCli(['releng', 'version', 'custom', '99.0.0', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // NPM checks
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
-        expect(rootPkg.version).to.equal('99.0.0');
+        expect(rootPkg.version).toBe('99.0.0');
 
         const workspacePkgs = findWorkspacePackageJsons(repoDir);
-        expect(workspacePkgs.length).to.be.greaterThan(0);
+        expect(workspacePkgs.length).toBeGreaterThan(0);
 
         // Theia README compatibility table should contain the new version
         const readme = readText(path.join(repoDir, 'README.md'));
-        expect(readme).to.contain('99.0.0');
+        expect(readme).toContain('99.0.0');
     });
 
     it('should set next version', function () {
         const result = runCli(['releng', 'version', 'next', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         const rootPkg = readJson(path.join(repoDir, 'package.json'));
-        expect(rootPkg.version as string).to.match(/-next$/);
+        expect(rootPkg.version as string).toMatch(/-next$/);
 
         const workspacePkgs = findWorkspacePackageJsons(repoDir);
-        expect(workspacePkgs.length).to.be.greaterThan(0);
+        expect(workspacePkgs.length).toBeGreaterThan(0);
         const firstPkg = readJson(workspacePkgs[0]);
-        expect(firstPkg.version as string).to.match(/-next$/);
+        expect(firstPkg.version as string).toMatch(/-next$/);
     });
 });
 
@@ -216,18 +216,18 @@ describe.skipIf(!isMavenAvailable())('releng version — glsp-server', function 
 
     it('should set custom version 99.0.0 in pom.xml', function () {
         const result = runCli(['releng', 'version', 'custom', '99.0.0', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         const pom = readText(path.join(repoDir, 'pom.xml'));
-        expect(pom).to.contain('<version>99.0.0</version>');
+        expect(pom).toContain('<version>99.0.0</version>');
     });
 
     it('should set next version as SNAPSHOT in pom.xml', function () {
         const result = runCli(['releng', 'version', 'next', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         const pom = readText(path.join(repoDir, 'pom.xml'));
-        expect(pom).to.match(/<version>\d+\.\d+\.\d+-SNAPSHOT<\/version>/);
+        expect(pom).toMatch(/<version>\d+\.\d+\.\d+-SNAPSHOT<\/version>/);
     });
 });
 
@@ -254,28 +254,28 @@ describe.skipIf(!isMavenAvailable())('releng version — glsp-eclipse-integratio
 
     it('should set custom version 99.0.0 in client and server', function () {
         const result = runCli(['releng', 'version', 'custom', '99.0.0', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Client npm packages
         const clientPkg = readJson(path.join(repoDir, 'client', 'package.json'));
-        expect(clientPkg.version).to.equal('99.0.0');
+        expect(clientPkg.version).toBe('99.0.0');
 
         // Server pom.xml
         const serverPom = readText(path.join(repoDir, 'server', 'pom.xml'));
-        expect(serverPom).to.contain('<version>99.0.0</version>');
+        expect(serverPom).toContain('<version>99.0.0</version>');
     });
 
     it('should set next version in client and server', function () {
         const result = runCli(['releng', 'version', 'next', '-r', repoDir], { timeout: 0 });
-        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).to.equal(0);
+        expect(result.exitCode, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
 
         // Client should have -next suffix
         const clientPkg = readJson(path.join(repoDir, 'client', 'package.json'));
-        expect(clientPkg.version as string).to.match(/-next$/);
+        expect(clientPkg.version as string).toMatch(/-next$/);
 
         // Server should have -SNAPSHOT suffix
         const serverPom = readText(path.join(repoDir, 'server', 'pom.xml'));
-        expect(serverPom).to.match(/<version>\d+\.\d+\.\d+-SNAPSHOT<\/version>/);
+        expect(serverPom).toMatch(/<version>\d+\.\d+\.\d+-SNAPSHOT<\/version>/);
     });
 });
 

--- a/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-core-build.e2e.spec.ts
@@ -39,10 +39,10 @@ describe('repo commands — core (build)', function () {
         workDir = createTempDir();
 
         const cloneResult = runCli(['repo', 'clone', '--preset', 'core', '-d', workDir]);
-        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).toBe(0);
 
         const buildResult = runCli(['repo', 'build', '-d', workDir]);
-        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).toBe(0);
     });
 
     afterAll(function () {
@@ -54,13 +54,13 @@ describe('repo commands — core (build)', function () {
     describe('build', function () {
         it('should have built all core repos', function () {
             for (const repo of CORE_REPOS) {
-                expect(fs.existsSync(path.join(workDir, repo, 'node_modules')), `${repo}/node_modules should exist`).to.be.true;
+                expect(fs.existsSync(path.join(workDir, repo, 'node_modules')), `${repo}/node_modules should exist`).toBe(true);
             }
         });
 
         it('should build with --repo filter', function () {
             const result = runCli(['repo', 'build', '-d', workDir, '-r', 'glsp-client']);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
         });
 
         it('should continue on failure with --no-fail-fast', function () {
@@ -75,7 +75,7 @@ describe('repo commands — core (build)', function () {
                 );
 
                 const result = runCli(['repo', 'build', '-d', badDir, '--no-fail-fast']);
-                expect(result.exitCode).to.not.equal(0);
+                expect(result.exitCode).not.toBe(0);
             } finally {
                 cleanupTempDir(badDir);
             }
@@ -87,12 +87,12 @@ describe('repo commands — core (build)', function () {
     describe('run', function () {
         it('should run a package script in a repo via scoped command', function () {
             const result = runCli(['repo', 'glsp-client', 'run', '--version', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
         });
 
         it('should fail when script does not exist', function () {
             const result = runCli(['repo', 'glsp-client', 'run', 'nonexistent-script-xyz', '-d', workDir]);
-            expect(result.exitCode).to.not.equal(0);
+            expect(result.exitCode).not.toBe(0);
         });
     });
 
@@ -108,8 +108,8 @@ describe('repo commands — core (build)', function () {
             }
 
             const result = runCli(['repo', 'glsp-server-node', 'browser-bundle', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(result.stdout).to.contain('wf-glsp-server-webworker.js');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(result.stdout).toContain('wf-glsp-server-webworker.js');
         });
 
         it('should print the node bundle path when bundle exists', function () {
@@ -119,8 +119,8 @@ describe('repo commands — core (build)', function () {
             fs.writeFileSync(bundleFile, 'fake-bundle');
 
             const result = runCli(['repo', 'glsp-server-node', 'node-bundle', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(result.stdout).to.contain('wf-glsp-server-node.js');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(result.stdout).toContain('wf-glsp-server-node.js');
         });
 
         it('should fail with helpful message when browser bundle is missing', function () {
@@ -128,9 +128,9 @@ describe('repo commands — core (build)', function () {
             try {
                 fs.mkdirSync(path.join(missingDir, 'glsp-server-node'), { recursive: true });
                 const result = runCli(['repo', 'glsp-server-node', 'browser-bundle', '-d', missingDir]);
-                expect(result.exitCode).to.not.equal(0);
+                expect(result.exitCode).not.toBe(0);
                 const output = result.stdout + result.stderr;
-                expect(output).to.contain('not found');
+                expect(output).toContain('not found');
             } finally {
                 cleanupTempDir(missingDir);
             }
@@ -141,9 +141,9 @@ describe('repo commands — core (build)', function () {
             try {
                 fs.mkdirSync(path.join(missingDir, 'glsp-server-node'), { recursive: true });
                 const result = runCli(['repo', 'glsp-server-node', 'node-bundle', '-d', missingDir]);
-                expect(result.exitCode).to.not.equal(0);
+                expect(result.exitCode).not.toBe(0);
                 const output = result.stdout + result.stderr;
-                expect(output).to.contain('not found');
+                expect(output).toContain('not found');
             } finally {
                 cleanupTempDir(missingDir);
             }
@@ -155,22 +155,22 @@ describe('repo commands — core (build)', function () {
     describe('link', function () {
         it('should link core repos via pnpm-workspace.yaml overrides', function () {
             const result = runCli(['repo', 'link', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
 
             // glsp-server-node should consume glsp-client's packages/singletons through link: overrides.
             const serverDir = path.join(workDir, 'glsp-server-node');
             const links = Object.entries(readOverrides(serverDir)).filter(([, value]) => value.startsWith('link:'));
-            expect(links.length, 'expected link: overrides in glsp-server-node').to.be.greaterThan(0);
+            expect(links.length, 'expected link: overrides in glsp-server-node').toBeGreaterThan(0);
             expect(
                 links.some(([, value]) => value.includes('glsp-client')),
                 'expected at least one override pointing into glsp-client'
-            ).to.be.true;
+            ).toBe(true);
 
             // A consumed override should resolve to the local glsp-client checkout.
             const consumed = links.find(([name]) => fs.existsSync(path.join(serverDir, 'node_modules', name)));
             if (consumed) {
                 const real = fs.realpathSync(path.join(serverDir, 'node_modules', consumed[0]));
-                expect(real.startsWith(fs.realpathSync(path.join(workDir, 'glsp-client')))).to.be.true;
+                expect(real.startsWith(fs.realpathSync(path.join(workDir, 'glsp-client')))).toBe(true);
             }
         });
     });
@@ -178,10 +178,10 @@ describe('repo commands — core (build)', function () {
     describe('unlink', function () {
         it('should unlink core repos', function () {
             const result = runCli(['repo', 'unlink', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
 
             const links = Object.values(readOverrides(path.join(workDir, 'glsp-server-node'))).filter(value => value.startsWith('link:'));
-            expect(links.length, 'link overrides should be removed after unlink').to.equal(0);
+            expect(links.length, 'link overrides should be removed after unlink').toBe(0);
         });
     });
 
@@ -190,26 +190,26 @@ describe('repo commands — core (build)', function () {
     describe('workspace', function () {
         it('should generate a .code-workspace file', function () {
             const result = runCli(['repo', 'workspace', 'init', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
 
             const wsFile = path.join(workDir, 'glsp.code-workspace');
-            expect(fs.existsSync(wsFile)).to.be.true;
+            expect(fs.existsSync(wsFile)).toBe(true);
 
             const ws = readJson(wsFile);
             const folders = ws.folders as { name: string; path: string }[];
-            expect(folders).to.have.length(2);
-            expect(folders.map(f => f.name)).to.include.members(['glsp-client', 'glsp-server-node']);
+            expect(folders).toHaveLength(2);
+            expect(folders.map(f => f.name)).toEqual(expect.arrayContaining(['glsp-client', 'glsp-server-node']));
         });
 
         it('should generate workspace with custom --output path', function () {
             const customPath = path.join(workDir, 'custom', 'my.code-workspace');
             const result = runCli(['repo', 'workspace', 'init', '-d', workDir, '-o', customPath]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(fs.existsSync(customPath)).to.be.true;
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(fs.existsSync(customPath)).toBe(true);
 
             const ws = readJson(customPath);
             const folders = ws.folders as { name: string; path: string }[];
-            expect(folders).to.have.length(2);
+            expect(folders).toHaveLength(2);
         });
     });
 });

--- a/dev-packages/cli/tests/e2e/repo/repo-core-clone.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-core-clone.e2e.spec.ts
@@ -28,7 +28,7 @@ describe('repo commands — core (clone)', function () {
     beforeAll(function () {
         workDir = createTempDir();
         const result = runCli(['repo', 'clone', '--preset', 'core', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
     });
 
     afterAll(function () {
@@ -41,9 +41,9 @@ describe('repo commands — core (clone)', function () {
         it('should clone all core repos via --preset', function () {
             for (const repo of CORE_REPOS) {
                 const repoDir = path.join(workDir, repo);
-                expect(fs.existsSync(repoDir), `${repo} should exist`).to.be.true;
-                expect(fs.existsSync(path.join(repoDir, 'package.json')), `${repo}/package.json should exist`).to.be.true;
-                expect(fs.existsSync(path.join(repoDir, '.git')), `${repo}/.git should exist`).to.be.true;
+                expect(fs.existsSync(repoDir), `${repo} should exist`).toBe(true);
+                expect(fs.existsSync(path.join(repoDir, 'package.json')), `${repo}/package.json should exist`).toBe(true);
+                expect(fs.existsSync(path.join(repoDir, '.git')), `${repo}/.git should exist`).toBe(true);
             }
         });
 
@@ -51,8 +51,8 @@ describe('repo commands — core (clone)', function () {
             const singleDir = createTempDir();
             try {
                 const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir]);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
-                expect(fs.existsSync(path.join(singleDir, 'glsp-client', 'package.json'))).to.be.true;
+                expect(result.exitCode, cliDiag(result)).toBe(0);
+                expect(fs.existsSync(path.join(singleDir, 'glsp-client', 'package.json'))).toBe(true);
             } finally {
                 cleanupTempDir(singleDir);
             }
@@ -62,12 +62,12 @@ describe('repo commands — core (clone)', function () {
             const singleDir = createTempDir();
             try {
                 const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir, '-p', 'ssh']);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(result.exitCode, cliDiag(result)).toBe(0);
 
                 const repoDir = path.join(singleDir, 'glsp-client');
-                expect(fs.existsSync(repoDir)).to.be.true;
+                expect(fs.existsSync(repoDir)).toBe(true);
                 const remoteUrl = git('remote get-url origin', repoDir);
-                expect(remoteUrl).to.contain('git@github.com:');
+                expect(remoteUrl).toContain('git@github.com:');
             } finally {
                 cleanupTempDir(singleDir);
             }
@@ -77,10 +77,10 @@ describe('repo commands — core (clone)', function () {
             const singleDir = createTempDir();
             try {
                 const result = runCli(['repo', 'glsp-client', 'clone', '-d', singleDir, '-b', 'master']);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(result.exitCode, cliDiag(result)).toBe(0);
 
                 const repoDir = path.join(singleDir, 'glsp-client');
-                expect(currentBranch(repoDir)).to.equal('master');
+                expect(currentBranch(repoDir)).toBe('master');
             } finally {
                 cleanupTempDir(singleDir);
             }
@@ -90,10 +90,10 @@ describe('repo commands — core (clone)', function () {
             const filterDir = createTempDir();
             try {
                 const result = runCli(['repo', 'clone', 'glsp-client', '-d', filterDir]);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(result.exitCode, cliDiag(result)).toBe(0);
 
-                expect(fs.existsSync(path.join(filterDir, 'glsp-client'))).to.be.true;
-                expect(fs.existsSync(path.join(filterDir, 'glsp-server-node'))).to.be.false;
+                expect(fs.existsSync(path.join(filterDir, 'glsp-client'))).toBe(true);
+                expect(fs.existsSync(path.join(filterDir, 'glsp-server-node'))).toBe(false);
             } finally {
                 cleanupTempDir(filterDir);
             }
@@ -107,12 +107,12 @@ describe('repo commands — core (clone)', function () {
                 fs.writeFileSync(marker, 'original');
 
                 const result = runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir, '--override', 'rename']);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(result.exitCode, cliDiag(result)).toBe(0);
 
                 const entries = fs.readdirSync(overrideDir).filter(e => e.startsWith('glsp-client_'));
-                expect(entries).to.have.lengthOf(1);
-                expect(fs.readFileSync(path.join(overrideDir, entries[0], 'test-marker.txt'), 'utf-8')).to.equal('original');
-                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).to.be.true;
+                expect(entries).toHaveLength(1);
+                expect(fs.readFileSync(path.join(overrideDir, entries[0], 'test-marker.txt'), 'utf-8')).toBe('original');
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).toBe(true);
             } finally {
                 cleanupTempDir(overrideDir);
             }
@@ -126,10 +126,10 @@ describe('repo commands — core (clone)', function () {
                 fs.writeFileSync(marker, 'original');
 
                 const result = runCli(['repo', 'glsp-client', 'clone', '-d', overrideDir, '--override', 'remove']);
-                expect(result.exitCode, cliDiag(result)).to.equal(0);
+                expect(result.exitCode, cliDiag(result)).toBe(0);
 
-                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'test-marker.txt'))).to.be.false;
-                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).to.be.true;
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'test-marker.txt'))).toBe(false);
+                expect(fs.existsSync(path.join(overrideDir, 'glsp-client', 'package.json'))).toBe(true);
             } finally {
                 cleanupTempDir(overrideDir);
             }
@@ -158,8 +158,8 @@ describe('repo commands — core (clone)', function () {
             git('checkout ' + origBranch, repoDir);
 
             const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'test-switch-branch', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(currentBranch(repoDir)).to.equal('test-switch-branch');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(currentBranch(repoDir)).toBe('test-switch-branch');
 
             git('checkout ' + origBranch, repoDir);
             git('branch -d test-switch-branch', repoDir);
@@ -167,10 +167,10 @@ describe('repo commands — core (clone)', function () {
 
         it('should warn when branch does not exist', function () {
             const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'nonexistent-branch-12345', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
 
             const combined = result.stdout + result.stderr;
-            expect(combined).to.contain('not found');
+            expect(combined).toContain('not found');
         });
 
         it('should fail without --force when repo has changes', function () {
@@ -179,7 +179,7 @@ describe('repo commands — core (clone)', function () {
             git('add dirty-marker.txt', repoDir);
 
             const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'master', '-d', workDir]);
-            expect(result.exitCode).to.not.equal(0);
+            expect(result.exitCode).not.toBe(0);
 
             resetRepo(repoDir);
         });
@@ -193,8 +193,8 @@ describe('repo commands — core (clone)', function () {
             git('add dirty-marker.txt', repoDir);
 
             const result = runCli(['repo', 'glsp-client', 'switch', '-b', 'test-force-branch', '--force', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(currentBranch(repoDir)).to.equal('test-force-branch');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(currentBranch(repoDir)).toBe('test-force-branch');
 
             git('checkout ' + origBranch, repoDir);
             git('branch -D test-force-branch', repoDir);
@@ -206,26 +206,26 @@ describe('repo commands — core (clone)', function () {
     describe('pwd', function () {
         it('should print resolved paths for all repos', function () {
             const result = runCli(['repo', 'pwd', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
             for (const repo of CORE_REPOS) {
-                expect(result.stdout).to.contain(repo);
+                expect(result.stdout).toContain(repo);
             }
         });
 
         it('should print raw tab-separated output', function () {
             const result = runCli(['repo', 'pwd', '-d', workDir, '--raw']);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
+            expect(result.exitCode, cliDiag(result)).toBe(0);
             const lines = result.stdout.trim().split('\n');
-            expect(lines).to.have.lengthOf(2);
+            expect(lines).toHaveLength(2);
             for (const line of lines) {
-                expect(line).to.match(/^glsp-\S+\t\//);
+                expect(line).toMatch(/^glsp-\S+\t\//);
             }
         });
 
         it('should print path for a single repo via scoped command', function () {
             const result = runCli(['repo', 'glsp-client', 'pwd', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(result.stdout.trim()).to.equal(path.resolve(workDir, 'glsp-client'));
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(result.stdout.trim()).toBe(path.resolve(workDir, 'glsp-client'));
         });
     });
 
@@ -234,15 +234,15 @@ describe('repo commands — core (clone)', function () {
     describe('log', function () {
         it('should print the last commit for all repos', function () {
             const result = runCli(['repo', 'log', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(result.stdout).to.contain('commit');
-            expect(result.stdout).to.contain('Author:');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(result.stdout).toContain('commit');
+            expect(result.stdout).toContain('Author:');
         });
 
         it('should print the last commit for a single repo via scoped command', function () {
             const result = runCli(['repo', 'glsp-client', 'log', '-d', workDir]);
-            expect(result.exitCode, cliDiag(result)).to.equal(0);
-            expect(result.stdout).to.contain('commit');
+            expect(result.exitCode, cliDiag(result)).toBe(0);
+            expect(result.stdout).toContain('commit');
         });
     });
 });

--- a/dev-packages/cli/tests/e2e/repo/repo-eclipse.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-eclipse.e2e.spec.ts
@@ -28,7 +28,7 @@ describe.skipIf(!isMavenAvailable())('repo commands — eclipse', function () {
         workDir = createTempDir();
 
         const cloneResult = runCli(['repo', 'clone', '--preset', 'eclipse', '-d', workDir]);
-        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).toBe(0);
 
         // Build with --no-fail-fast so all repos are attempted even if one fails.
         // The Tycho build for glsp-eclipse-integration/server depends on Eclipse p2
@@ -44,16 +44,16 @@ describe.skipIf(!isMavenAvailable())('repo commands — eclipse', function () {
 
     it('should have built glsp-server with Maven', function () {
         const targetDir = path.join(workDir, 'glsp-server', 'examples', 'org.eclipse.glsp.example.workflow', 'target');
-        expect(fs.existsSync(targetDir), 'Maven target directory should exist').to.be.true;
+        expect(fs.existsSync(targetDir), 'Maven target directory should exist').toBe(true);
     });
 
     it('should build glsp-server via scoped command', function () {
         const result = runCli(['repo', 'glsp-server', 'build', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
     });
 
     it('should build glsp-eclipse-integration via scoped command', function () {
         const result = runCli(['repo', 'glsp-eclipse-integration', 'build', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
     });
 });

--- a/dev-packages/cli/tests/e2e/repo/repo-theia.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-theia.e2e.spec.ts
@@ -25,10 +25,10 @@ describe('repo commands — theia', function () {
         workDir = createTempDir();
 
         const cloneResult = runCli(['repo', 'clone', '--preset', 'theia', '-d', workDir]);
-        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).toBe(0);
 
         const buildResult = runCli(['repo', 'build', '-d', workDir]);
-        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).toBe(0);
     });
 
     afterAll(function () {
@@ -37,6 +37,6 @@ describe('repo commands — theia', function () {
 
     it('should build theia-integration with scoped build', function () {
         const result = runCli(['repo', 'glsp-theia-integration', 'build', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
     });
 });

--- a/dev-packages/cli/tests/e2e/repo/repo-vscode.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/repo/repo-vscode.e2e.spec.ts
@@ -27,10 +27,10 @@ describe('repo commands — vscode', function () {
         workDir = createTempDir();
 
         const cloneResult = runCli(['repo', 'clone', '--preset', 'vscode', '-d', workDir]);
-        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).to.equal(0);
+        expect(cloneResult.exitCode, `clone failed:\n${cliDiag(cloneResult)}`).toBe(0);
 
         const buildResult = runCli(['repo', 'build', '-d', workDir]);
-        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).to.equal(0);
+        expect(buildResult.exitCode, `build failed:\n${cliDiag(buildResult)}`).toBe(0);
     });
 
     afterAll(function () {
@@ -39,54 +39,54 @@ describe('repo commands — vscode', function () {
 
     it('should build vscode-integration with scoped build', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'build', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
     });
 
     // ── Package ───────────────────────────────────────────────────────────
 
     it('should package the VS Code extension as VSIX', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'package', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
 
         const vsixDir = path.join(workDir, 'glsp-vscode-integration', 'example', 'workflow', 'extension');
         const vsixFiles = fs.readdirSync(vsixDir).filter(f => f.endsWith('.vsix'));
-        expect(vsixFiles).to.have.lengthOf.at.least(1);
+        expect(vsixFiles.length).toBeGreaterThanOrEqual(1);
     });
 
     it('should package the VS Code web extension as VSIX', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'web-package', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
 
         const vsixDir = path.join(workDir, 'glsp-vscode-integration', 'example', 'workflow', 'web-extension');
         const vsixFiles = fs.readdirSync(vsixDir).filter(f => f.endsWith('.vsix'));
-        expect(vsixFiles).to.have.lengthOf.at.least(1);
+        expect(vsixFiles.length).toBeGreaterThanOrEqual(1);
     });
 
     // ── VSIX path ─────────────────────────────────────────────────────────
 
     it('should print the VSIX path after packaging', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'vsix-path', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
-        expect(result.stdout).to.match(/\.vsix$/);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
+        expect(result.stdout).toMatch(/\.vsix$/);
     });
 
     it('should print the web extension VSIX path after packaging', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'web-vsix-path', '-d', workDir]);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
-        expect(result.stdout).to.match(/\.vsix$/);
+        expect(result.exitCode, cliDiag(result)).toBe(0);
+        expect(result.stdout).toMatch(/\.vsix$/);
     });
 
     // ── VSIX ID ───────────────────────────────────────────────────────────
 
     it('should print the VSIX ID', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'vsix-id']);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
-        expect(result.stdout).to.equal('eclipse-glsp.workflow-vscode-example');
+        expect(result.exitCode, cliDiag(result)).toBe(0);
+        expect(result.stdout).toBe('eclipse-glsp.workflow-vscode-example');
     });
 
     it('should print the web extension VSIX ID', function () {
         const result = runCli(['repo', 'glsp-vscode-integration', 'web-vsix-id']);
-        expect(result.exitCode, cliDiag(result)).to.equal(0);
-        expect(result.stdout).to.equal('eclipse-glsp.workflow-vscode-example-web');
+        expect(result.exitCode, cliDiag(result)).toBe(0);
+        expect(result.stdout).toBe('eclipse-glsp.workflow-vscode-example-web');
     });
 });

--- a/dev-packages/cli/tests/e2e/update-next.e2e.spec.ts
+++ b/dev-packages/cli/tests/e2e/update-next.e2e.spec.ts
@@ -40,12 +40,12 @@ describe('updateNext e2e', () => {
         fs.writeFileSync(pkgPath, JSON.stringify({ name: 'test', version: '1.0.1', private: true, workspaces: [] }, undefined, 2));
         const result = runCli(['updateNext', repoDir]);
         // LOGGER.warn uses console.warn which writes to stderr
-        expect(result.stderr).to.contain('Uncommitted changes');
+        expect(result.stderr).toContain('Uncommitted changes');
     });
 
     it('should error for non-existent directory', () => {
         const result = runCli(['updateNext', '/non/existent/path']);
-        expect(result.exitCode).to.not.equal(0);
+        expect(result.exitCode).not.toBe(0);
     });
 
     it('should show debug output with --verbose', () => {
@@ -56,6 +56,6 @@ describe('updateNext e2e', () => {
         execSync('git add . && git commit -m "add package.json"', { cwd: repoDir });
         const result = runCli(['updateNext', repoDir, '--verbose']);
         const output = result.stdout + result.stderr;
-        expect(output).to.contain('Scanning');
+        expect(output).toContain('Scanning');
     });
 });

--- a/dev-packages/config/package.json
+++ b/dev-packages/config/package.json
@@ -33,7 +33,6 @@
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
-    "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-no-null": "^1.0.2",
     "globals": "^17.6.0",

--- a/dev-packages/eslint-config/configs/base.js
+++ b/dev-packages/eslint-config/configs/base.js
@@ -3,7 +3,6 @@ const tseslint = require('typescript-eslint');
 const importX = require('eslint-plugin-import-x');
 const header = require('@tony.ganchev/eslint-plugin-header');
 const noNull = require('eslint-plugin-no-null');
-const chaiFriendly = require('eslint-plugin-chai-friendly');
 const stylistic = require('@stylistic/eslint-plugin');
 const globals = require('globals');
 
@@ -22,14 +21,12 @@ module.exports = [
             },
             globals: {
                 ...globals.browser,
-                ...globals.mocha,
                 ...globals.es2015
             }
         },
         plugins: {
             header: header,
             'no-null': noNull,
-            'chai-friendly': chaiFriendly,
             '@stylistic': stylistic
         }
     }

--- a/dev-packages/eslint-config/configs/errors.js
+++ b/dev-packages/eslint-config/configs/errors.js
@@ -75,9 +75,7 @@ module.exports = [
             'import-x/export': 'off', // we have multiple exports due to namespaces, enums and classes that share the same name
             // eslint-plugin-no-null
             'no-null/no-null': 'error',
-            // chai friendly
-            'no-unused-expressions': 'off',
-            'chai-friendly/no-unused-expressions': [
+            'no-unused-expressions': [
                 'error',
                 {
                     allowShortCircuit: true,

--- a/dev-packages/eslint-config/package.json
+++ b/dev-packages/eslint-config/package.json
@@ -38,7 +38,6 @@
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
-    "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-no-null": "^1.0.2",
     "globals": "^17.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "publish:latest": "glsp releng publish latest",
     "publish:next": "glsp releng publish next",
     "test": "pnpm -C dev-packages/cli test",
+    "test:coverage": "pnpm -C dev-packages/cli test:coverage",
     "test:e2e": "pnpm -C dev-packages/cli test:e2e",
     "watch": "pnpm cli watch"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       eslint-import-resolver-typescript:
         specifier: ^4.0.0
         version: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
-      eslint-plugin-chai-friendly:
-        specifier: ^1.0.0
-        version: 1.2.1(eslint@10.5.0)
       eslint-plugin-import-x:
         specifier: ^4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
@@ -149,9 +146,6 @@ importers:
       eslint-import-resolver-typescript:
         specifier: ^4.0.0
         version: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
-      eslint-plugin-chai-friendly:
-        specifier: ^1.0.0
-        version: 1.2.1(eslint@10.5.0)
       eslint-plugin-import-x:
         specifier: ^4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
@@ -954,12 +948,6 @@ packages:
         optional: true
       eslint-plugin-import-x:
         optional: true
-
-  eslint-plugin-chai-friendly@1.2.1:
-    resolution: {integrity: sha512-mV3EOJLDr8+L+LS8uCkP711fnNHz+4PsmPyz18xwkvjJwfLRlnx0Eu6CFnb5B+dW5ahoav2jVer2KFYsmIuv3A==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      eslint: '>=3.0.0'
 
   eslint-plugin-import-x@4.16.2:
     resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
@@ -2279,10 +2267,6 @@ snapshots:
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  eslint-plugin-chai-friendly@1.2.1(eslint@10.5.0):
-    dependencies:
-      eslint: 10.5.0
 
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0):
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Follow-up to the Vitest migration (#1705): converts the remaining chai-style
BDD assertions in all spec files to native Vitest matchers and drops the
now-unused chai tooling.

- Migrate all spec assertions across 35 files (`.to.equal` → `toBe`,
  `.to.deep.equal` → `toEqual`, `.to.include.members([...])` →
  `toEqual(expect.arrayContaining([...]))`, `.to.throw` → `toThrow`, etc.)
- Remove `eslint-plugin-chai-friendly` from the `config` and `eslint-config`
  packages and re-enable the core `no-unused-expressions` rule, which is correct
  again now that assertions are function calls rather than property accesses
- Drop the obsolete `globals.mocha` entry from the base ESLint config
- Remove stale `ctrf/` and `.nyc_output/` entries from `.gitignore`
- Add a `test:coverage` passthrough script to the root `package.json`

Part of: eclipse-glsp/glsp#1635

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

```
pnpm install
pnpm test
```

- [x] Full CLI unit suite passes (22 files, 395 tests) — verified locally
- [x] No chai/mocha/sinon references remain in `dev-packages/cli/src` or `tests`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
